### PR TITLE
docs(governance): gate runbook-adr decision surface

### DIFF
--- a/.github/workflows/validate-runbook-adr-links.yml
+++ b/.github/workflows/validate-runbook-adr-links.yml
@@ -1,0 +1,136 @@
+name: validate-runbook-adr-links
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - "docs/runbooks/**"
+      - "docs/design/adr/**"
+      - ".github/workflows/validate-runbook-adr-links.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate runbook <-> ADR linkage
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          ROOT = Path('.')
+          RUNBOOK_DIR = ROOT / 'docs' / 'runbooks'
+          ADR_DIR = ROOT / 'docs' / 'design' / 'adr'
+
+          errors = []
+
+          def parse_front_matter(path: Path):
+            text = path.read_text(encoding='utf-8')
+            if not text.startswith('---\n'):
+              return None, text
+            parts = text.split('---\n', 2)
+            if len(parts) < 3:
+              return None, text
+            return parts[1], parts[2]
+
+          def get_scalar(fm: str, key: str):
+            m = re.search(rf'^{re.escape(key)}:\s*(.+)$', fm, flags=re.M)
+            return m.group(1).strip() if m else None
+
+          def get_decisions(fm: str):
+            lines = fm.splitlines()
+            out = []
+            in_block = False
+            for line in lines:
+              if line.startswith('decisions:'):
+                in_block = True
+                continue
+              if in_block:
+                if re.match(r'^[A-Za-z0-9_\-]+:', line):
+                  break
+                m = re.match(r'^\s*-\s+(.+)$', line)
+                if m:
+                  out.append(m.group(1).strip())
+            return out
+
+          def get_applies_to(fm: str):
+            m = re.search(r'^applies_to:\n(?:\s{2}.+\n?)+', fm, flags=re.M)
+            if not m:
+              return {}
+            block = m.group(0)
+            runbook = re.search(r'^\s{2}runbook:\s*(.+)$', block, flags=re.M)
+            phase = re.search(r'^\s{2}phase:\s*(.+)$', block, flags=re.M)
+            anchor = re.search(r'^\s{2}anchor:\s*"?([^"]+)"?$', block, flags=re.M)
+            return {
+              'runbook': runbook.group(1).strip() if runbook else '',
+              'phase': phase.group(1).strip() if phase else '',
+              'anchor': anchor.group(1).strip() if anchor else '',
+            }
+
+          runbooks = []
+          for p in sorted(RUNBOOK_DIR.glob('*.md')):
+            fm, body = parse_front_matter(p)
+            if not fm:
+              continue
+            rb_id = get_scalar(fm, 'id')
+            if not rb_id or not rb_id.startswith('RB-'):
+              continue
+            decisions = get_decisions(fm)
+            if not decisions:
+              errors.append(f"Runbook missing decisions list: {p}")
+            for d in decisions:
+              target = ROOT / d
+              if not target.exists():
+                errors.append(f"Runbook references missing ADR: {p} -> {d}")
+            runbooks.append((p, fm, body, decisions))
+
+          adrs = []
+          for p in sorted(ADR_DIR.glob('ADR-*.md')):
+            if p.name == 'ADR-000-template.md':
+              continue
+            fm, body = parse_front_matter(p)
+            if not fm:
+              errors.append(f"ADR missing front matter: {p}")
+              continue
+
+            adr_id = get_scalar(fm, 'id') or ''
+            status = (get_scalar(fm, 'status') or '').lower()
+            if not adr_id.startswith('ADR-'):
+              errors.append(f"ADR id invalid/missing in {p}")
+
+            applies = get_applies_to(fm)
+            runbook = applies.get('runbook', '')
+            phase = applies.get('phase', '')
+            anchor = applies.get('anchor', '')
+
+            # strong rule: accepted ADRs must have applies_to complete
+            if status == 'accepted':
+              if not (runbook and phase and anchor):
+                errors.append(f"Accepted ADR missing applies_to fields: {p}")
+
+            # base rule: every ADR must declare applies_to
+            if not (runbook and phase and anchor):
+              errors.append(f"ADR missing applies_to linkage: {p}")
+            else:
+              rb_path = ROOT / runbook
+              if not rb_path.exists():
+                errors.append(f"ADR references missing runbook: {p} -> {runbook}")
+              else:
+                rb_text = rb_path.read_text(encoding='utf-8')
+                anchor_id = anchor[1:] if anchor.startswith('#') else anchor
+                has_anchor = (anchor in rb_text) or (f'id=\"{anchor_id}\"' in rb_text) or (f"id='{anchor_id}'" in rb_text)
+                if not has_anchor:
+                  errors.append(f"ADR anchor not found in runbook: {p} -> {runbook} ({anchor})")
+
+            adrs.append((p, status, runbook, phase, anchor))
+
+          if errors:
+            print('Runbook/ADR validation errors:')
+            for e in errors:
+              print(f'- {e}')
+            sys.exit(1)
+
+          print('Runbook <-> ADR linkage validation passed.')
+          PY

--- a/docs/design/adr/ADR-001-single-runtime.md
+++ b/docs/design/adr/ADR-001-single-runtime.md
@@ -1,3 +1,13 @@
+---
+id: ADR-001
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/root-hardening.md
+  phase: 0.1.0
+  anchor: "#phase-0-1-0-protocol-guardrails"
+---
 # ADR-001 — Single Runtime Per Machine (Canonical)
 
 ## Context

--- a/docs/design/adr/ADR-002-root-entrypoint.md
+++ b/docs/design/adr/ADR-002-root-entrypoint.md
@@ -1,3 +1,13 @@
+---
+id: ADR-002
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/root-hardening.md
+  phase: 0.1.1
+  anchor: "#phase-0-1-1-byte-perfect-router"
+---
 # ADR-002 — Root Control Plane as Canonical Entry Point
 
 ## Context

--- a/docs/design/adr/ADR-003-kernel-authority.md
+++ b/docs/design/adr/ADR-003-kernel-authority.md
@@ -1,3 +1,13 @@
+---
+id: ADR-003
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/root-hardening.md
+  phase: 0.1.2
+  anchor: "#phase-0-1-2-envelope-authority-gate"
+---
 # ADR-003 — Kernel as Authority Plane (L1)
 
 ## Context

--- a/docs/design/adr/ADR-004-engine-execution.md
+++ b/docs/design/adr/ADR-004-engine-execution.md
@@ -1,3 +1,13 @@
+---
+id: ADR-004
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/engine-attach.md
+  phase: v4
+  anchor: "#phase-engine-attach-v4"
+---
 # ADR-004 — Engine as Execution Plane (L2)
 
 ## Context

--- a/docs/design/adr/ADR-005-mind-proposer.md
+++ b/docs/design/adr/ADR-005-mind-proposer.md
@@ -1,3 +1,13 @@
+---
+id: ADR-005
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/mind-redis-stm.md
+  phase: v5.3
+  anchor: "#phase-mind-proposer"
+---
 # ADR-005 — Mind Per Workspace (L3 Cognitive Plane)
 
 ## Context

--- a/docs/design/adr/ADR-006-unified-rpc.md
+++ b/docs/design/adr/ADR-006-unified-rpc.md
@@ -1,3 +1,13 @@
+---
+id: ADR-006
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/root-hardening.md
+  phase: 0.1.0
+  anchor: "#phase-0-1-0-protocol-guardrails"
+---
 # ADR-006 — Strict Unified RPC Contract
 
 ## Context

--- a/docs/design/adr/ADR-007-workspace-isolation.md
+++ b/docs/design/adr/ADR-007-workspace-isolation.md
@@ -1,3 +1,13 @@
+---
+id: ADR-007
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/workspaces-lifecycle.md
+  phase: 0.1.0
+  anchor: "#phase-0-1-0-workspace-layout"
+---
 # ADR-007 — Workspace Isolation Model
 
 ## Context

--- a/docs/design/adr/ADR-008-connection-lifecycle.md
+++ b/docs/design/adr/ADR-008-connection-lifecycle.md
@@ -1,3 +1,13 @@
+---
+id: ADR-008
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/workspaces-lifecycle.md
+  phase: 0.1.1
+  anchor: "#phase-0-1-1-ws-create-guardrails"
+---
 # ADR-008 — Connection Lifecycle Semantics
 
 ## Context

--- a/docs/design/adr/ADR-009-engine-attachment.md
+++ b/docs/design/adr/ADR-009-engine-attachment.md
@@ -1,3 +1,13 @@
+---
+id: ADR-009
+status: draft
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/engine-attach.md
+  phase: v4
+  anchor: "#phase-engine-attach-v4"
+---
 # ADR-009 — Engine Attachment Model (Next Phase)
 
 ## Context

--- a/docs/design/adr/ADR-010-boot-entrypoint.md
+++ b/docs/design/adr/ADR-010-boot-entrypoint.md
@@ -1,3 +1,13 @@
+---
+id: ADR-010
+status: accepted
+effective_date: 2026-02-18
+supersedes: []
+applies_to:
+  runbook: docs/runbooks/root-hardening.md
+  phase: boot-baseline
+  anchor: "#phase-root-boot-baseline"
+---
 # ADR-010 — Boot as Canonical Machine Entry
 
 ## Context

--- a/docs/runbooks/engine-attach.md
+++ b/docs/runbooks/engine-attach.md
@@ -5,6 +5,7 @@
 
 ---
 
+<a id="phase-engine-attach-v4"></a>
 ## Objective (v4)
 
 Bring L2 Engine "inside" the governed L0↔L1 pipeline:

--- a/docs/runbooks/mind-redis-stm.md
+++ b/docs/runbooks/mind-redis-stm.md
@@ -389,6 +389,7 @@ impl WorkspaceCtx {
 }
 ```
 
+<a id="phase-mind-proposer"></a>
 ### E) Proposer (proposal-only)
 
 **File:** `mind/src/proposals/mod.rs`

--- a/docs/runbooks/root-hardening.md
+++ b/docs/runbooks/root-hardening.md
@@ -8,6 +8,10 @@ revision: 1
 supersedes: []
 depends_on:
   - RB-WORKSPACES-LIFECYCLE (optional, if already exists)
+decisions:
+  - docs/design/adr/ADR-002-root-entrypoint.md
+  - docs/design/adr/ADR-006-unified-rpc.md
+  - docs/design/adr/ADR-008-connection-lifecycle.md
 related:
   adr:
     - docs/design/adr/ADR-002-root-entrypoint.md
@@ -40,6 +44,12 @@ Root must behave like a governed cable:
 - logs everything in an indestructible way
 
 This runbook does NOT redesign architecture. It strengthens enforcement and observability without changing the planes model.
+
+## Decisions
+
+- docs/design/adr/ADR-002-root-entrypoint.md
+- docs/design/adr/ADR-006-unified-rpc.md
+- docs/design/adr/ADR-008-connection-lifecycle.md
 
 ---
 
@@ -93,6 +103,7 @@ pkill -f yai-boot || true
 rm -rf ~/.yai/run/root/root.log || true
 ```
 
+<a id="phase-root-boot-baseline"></a>
 ### Build + boot baseline
 
 ```bash
@@ -121,6 +132,7 @@ Each phase must compile, run, and be verifiable before moving on.
 
 ---
 
+<a id="phase-0-1-0-protocol-guardrails"></a>
 ### 0.1.0 — Protocol Guardrails (no business logic)
 
 **Branch:** `feat/root-hardening-0.1.0-guardrails`  
@@ -180,6 +192,7 @@ Minimum set expected:
 
 ---
 
+<a id="phase-0-1-1-byte-perfect-router"></a>
 ### 0.1.1 — Root = Byte-Perfect Router (forward/relay)
 
 **Branch:** `feat/root-hardening-0.1.1-router`  
@@ -257,6 +270,7 @@ Protocol negative tests (at least):
 
 ---
 
+<a id="phase-0-1-2-envelope-authority-gate"></a>
 ### 0.1.2 — Envelope-Only Authority Gate (Root + Kernel)
 
 **Branch:** `feat/root-hardening-0.1.2-authority-gate`  

--- a/docs/runbooks/workspaces-lifecycle.md
+++ b/docs/runbooks/workspaces-lifecycle.md
@@ -8,6 +8,9 @@ revision: 1
 supersedes: []
 depends_on:
   - RB-ROOT-HARDENING
+decisions:
+  - docs/design/adr/ADR-007-workspace-isolation.md
+  - docs/design/adr/ADR-008-connection-lifecycle.md
 related:
   adr:
     - docs/design/adr/ADR-007-workspace-isolation.md
@@ -34,6 +37,11 @@ Non-negotiable outcomes:
 - `yai kernel ws destroy <id>` removes deterministically, guarded against traversal
 - Root remains a pure router (envelope validation + byte-perfect forward/relay)
 - Kernel enforces policy and applies side-effects only when valid + authorized
+
+## Decisions
+
+- docs/design/adr/ADR-007-workspace-isolation.md
+- docs/design/adr/ADR-008-connection-lifecycle.md
 
 ---
 
@@ -122,6 +130,7 @@ Expected:
 
 ---
 
+<a id="phase-0-1-0-workspace-layout"></a>
 ### 0.1.0 — Define Minimal Workspace Layout + Manifest Stub
 
 **Branch:** `feat/workspaces-lifecycle-0.1.0-layout`  
@@ -179,6 +188,7 @@ Confirm:
 
 ---
 
+<a id="phase-0-1-1-ws-create-guardrails"></a>
 ### 0.1.1 — Kernel Implements ws.create With Guardrails
 
 **Branch:** `feat/workspaces-lifecycle-0.1.1-ws-create`  


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): governance blindage for decision surface (runbook ↔ ADR)
- Base-Commit: 2e7e54e5b4d56e8b1f6d2c95ce2d1a7c3a0fd1af

## Objective
Enforce bidirectional traceability between Runbooks and ADRs:
- no runbook without declared ADR decisions
- no ADR without explicit runbook/phase/anchor applicability
- CI gate fails on broken links or missing decision metadata

## Classification
- Classification: META
- Compatibility: A

## Changes
- Added CI gate:
  - `.github/workflows/validate-runbook-adr-links.yml`
- Updated ADRs `ADR-001..ADR-010` with canonical front-matter:
  - `id`
  - `status` (`accepted|draft`)
  - `effective_date`
  - `supersedes`
  - `applies_to` (`runbook`, `phase`, `anchor`)
- Updated runbooks with explicit decision linkage:
  - `docs/runbooks/root-hardening.md`
  - `docs/runbooks/workspaces-lifecycle.md`
  - plus phase anchors in:
    - `docs/runbooks/engine-attach.md`
    - `docs/runbooks/mind-redis-stm.md`

## Evidence
Positive:
- Validator passes when all runbook ↔ ADR links and anchors are coherent.
- Accepted ADRs with complete `applies_to` are accepted by the gate.

Negative:
- Breaking ADR→runbook link (`runbook: docs/runbooks/DOES-NOT-EXIST.md`) causes fail.
- Missing/non-resolvable anchor causes fail.

## Commands run
```bash
# local validation pass
python3 <validator-snippet>   # equivalent logic used in workflow
# output: PASS

# break-link test (expected fail), then restore
cp docs/design/adr/ADR-006-unified-rpc.md /tmp/ADR-006-unified-rpc.md.bak
# mutate runbook path to invalid
# run validator
# output: FAIL (expected)
cp /tmp/ADR-006-unified-rpc.md.bak docs/design/adr/ADR-006-unified-rpc.md

# final pass
python3 <validator-snippet>
# output: PASS
```

## Scope guardrails
In-scope:
- `docs/runbooks/*` governance metadata
- `docs/design/adr/*` applicability metadata
- CI workflow for link integrity

Out-of-scope:
- runtime/kernel/engine/root behavior changes
- protocol semantics changes
- tooling automation beyond ADR/runbook linkage gate

## Checklist
- [x] Runbooks declare ADR decisions
- [x] ADRs declare runbook/phase/anchor applicability
- [x] Broken link test produces red gate
- [x] Restored linkage produces green gate
