### PR TITLE
docs(adr): rewrite and align canonical ADR set with law refs

### DIFF
--- a/docs/design/adr/ADR-001-single-runtime.md
+++ b/docs/design/adr/ADR-001-single-runtime.md
@@ -7,65 +7,42 @@ applies_to:
   runbook: docs/runbooks/root-hardening.md
   phase: 0.1.0
   anchor: "#phase-0-1-0-protocol-guardrails"
+law_refs:
+  - deps/yai-specs/contracts/axioms/A-002-authority.md
+  - deps/yai-specs/contracts/invariants/I-003-governance.md
+  - deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md
+  - deps/yai-specs/contracts/boundaries/L1-kernel.md
+  - deps/yai-specs/contracts/boundaries/L2-engine.md
 ---
-# ADR-001 — Single Runtime Per Machine (Canonical)
+# ADR-001 - Single Runtime Per Machine
 
 ## Context
 
-# YAI Architecture Decisions (Law-Aligned, 2026 Revision)
+YAI is evolving from a mixed execution model toward a machine-level runtime. The previous shape allowed multiple implicit entry paths and per-workspace execution assumptions that made governance and evidence weaker.
 
-This document captures the **machine-level architecture commitments**
-of YAI as of the current runtime refactor phase.
+## Decision
 
-It is grounded in `deps/yai-specs/contracts/` invariants and reflects the
-post-envelope, post-authority enforcement state.
+YAI adopts one canonical machine runtime composed of:
 
-The architecture is stratified across:
+- Root control plane
+- Kernel (L1 authority plane)
+- Engine (L2 execution plane)
 
-- L0 — Vault (immutable identity & ABI boundary)
-- L1 — Kernel (authority, sessions, isolation)
-- L2 — Engine (execution gates)
-- L3 — Mind (proposal-only cognition per workspace)
-- Root — Machine Control Plane (runtime governor)
+Workspaces are logical tenants managed by this runtime, not independent daemon stacks.
 
----
+## Rationale
 
-### Decision
+A single runtime reduces authority ambiguity, improves observability, and strengthens deterministic enforcement of workspace boundaries.
 
-YAI runs as **one machine-level runtime**, composed of:
+## Consequences
 
-- Root Control Plane
-- Kernel (L1)
-- Engine (L2)
-
-This runtime manages multiple workspaces concurrently.
-
-### Implications
-
-- No per-workspace daemon model long-term.
-- No direct CLI-to-workspace socket access.
-- The runtime is machine-scoped, not workspace-scoped.
-
-### Constraints
-
-- All runtime-bound requests MUST carry `ws_id`.
-- Kernel MUST enforce isolation between workspaces.
-- Engine MUST execute effects only under Kernel authority.
-- Cross-workspace state sharing is forbidden by default.
-
-### Law Alignment
-
-- A-002 Authority
-- I-006 External Effect Boundary
-- L1/L2 boundary enforcement
-
-### Status
-
-Architecture locked.
-Implementation staged (Root stub active, full multi-tenant pending).
-
----
+- Positive:
+  - One authoritative ingress and lifecycle model.
+  - Better cross-workspace governance and auditable routing.
+- Negative:
+  - Legacy assumptions around direct workspace access must be removed.
+  - Migration work is required in boot/routing and operational docs.
 
 ## Status
 
-Active
+Accepted and active.

--- a/docs/design/adr/ADR-003-kernel-authority.md
+++ b/docs/design/adr/ADR-003-kernel-authority.md
@@ -7,64 +7,42 @@ applies_to:
   runbook: docs/runbooks/root-hardening.md
   phase: 0.1.2
   anchor: "#phase-0-1-2-envelope-authority-gate"
+law_refs:
+  - deps/yai-specs/contracts/axioms/A-002-authority.md
+  - deps/yai-specs/contracts/invariants/I-003-governance.md
+  - deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md
+  - deps/yai-specs/contracts/boundaries/L1-kernel.md
+  - deps/yai-specs/specs/protocol/include/auth.h
+  - deps/yai-specs/specs/protocol/include/session.h
 ---
-# ADR-003 — Kernel as Authority Plane (L1)
+# ADR-003 - Kernel as Authority Plane (L1)
 
 ## Context
 
-# YAI Architecture Decisions (Law-Aligned, 2026 Revision)
+Authority checks were historically mixed with execution paths. This weakened guarantees around role/arming/workspace enforcement.
 
-This document captures the **machine-level architecture commitments**
-of YAI as of the current runtime refactor phase.
+## Decision
 
-It is grounded in `deps/yai-specs/contracts/` invariants and reflects the
-post-envelope, post-authority enforcement state.
+Kernel is the sole authority plane and validates:
 
-The architecture is stratified across:
+- Handshake and protocol conformance
+- Role and arming constraints
+- Workspace binding and session ownership
 
-- L0 — Vault (immutable identity & ABI boundary)
-- L1 — Kernel (authority, sessions, isolation)
-- L2 — Engine (execution gates)
-- L3 — Mind (proposal-only cognition per workspace)
-- Root — Machine Control Plane (runtime governor)
+No effectful execution is allowed before Kernel authorization.
 
----
+## Rationale
 
-### Decision
+Separating authority from execution preserves deterministic policy behavior and ensures that Engine cannot be used as an authorization surface.
 
-Kernel is the **authority enforcement layer**.
+## Consequences
 
-It validates:
-
-- protocol version
-- handshake
-- role
-- arming flag
-- ws_id
-- session ownership
-
-It is the only layer that may authorize effectful execution.
-
-### Enforcement Rules
-
-- `arming=true` requires role ≥ operator
-- No execution without handshake
-- No execution before workspace attach
-- No cross-workspace session mixing
-
-### Non-Goals
-
-- Kernel does not perform business logic
-- Kernel does not execute provider/storage logic
-- Kernel does not own cognition
-
-### Status
-
-Authority enforcement active.
-Session locking stabilized (robust PID validation).
-
----
+- Positive:
+  - Clear trust boundary between policy and execution.
+  - Consistent reject semantics for unauthorized requests.
+- Negative:
+  - Additional coordination needed when evolving command lifecycle.
 
 ## Status
 
-Active
+Accepted and active.

--- a/docs/design/adr/ADR-004-engine-execution.md
+++ b/docs/design/adr/ADR-004-engine-execution.md
@@ -7,61 +7,40 @@ applies_to:
   runbook: docs/runbooks/engine-attach.md
   phase: v4
   anchor: "#phase-engine-attach-v4"
+law_refs:
+  - deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md
+  - deps/yai-specs/contracts/boundaries/L2-engine.md
+  - deps/yai-specs/specs/protocol/include/protocol.h
+  - deps/yai-specs/specs/protocol/include/transport.h
 ---
-# ADR-004 — Engine as Execution Plane (L2)
+# ADR-004 - Engine as Execution Plane (L2)
 
 ## Context
 
-# YAI Architecture Decisions (Law-Aligned, 2026 Revision)
+Execution responsibilities must stay isolated from authority checks to keep runtime behavior auditable and composable.
 
-This document captures the **machine-level architecture commitments**
-of YAI as of the current runtime refactor phase.
+## Decision
 
-It is grounded in `deps/yai-specs/contracts/` invariants and reflects the
-post-envelope, post-authority enforcement state.
+Engine is the execution plane for gates and workloads (storage/provider/network/resource/cortex) and operates only after Kernel authorization.
 
-The architecture is stratified across:
+Engine must not:
 
-- L0 — Vault (immutable identity & ABI boundary)
-- L1 — Kernel (authority, sessions, isolation)
-- L2 — Engine (execution gates)
-- L3 — Mind (proposal-only cognition per workspace)
-- Root — Machine Control Plane (runtime governor)
+- Perform authority validation
+- Choose workspace ownership
+- Open alternative policy channels
 
----
+## Rationale
 
-### Decision
+A strict L1-to-L2 handoff keeps effect boundaries explicit and simplifies traceability from command to governed execution.
 
-Engine is the **execution gate layer**.
+## Consequences
 
-It provides:
-
-- storage_gate
-- provider_gate
-- network_gate
-- resource_gate
-- cortex execution
-
-Engine executes only after Kernel authorization.
-
-### Rules
-
-- Engine never validates authority
-- Engine never selects workspace
-- Engine never bypasses Kernel
-
-### Relationship
-
-Kernel → Engine (downward call)
-Engine → Kernel (never)
-
-### Status
-
-Engine routing stub integrated.
-Full integration with Root pending.
-
----
+- Positive:
+  - Cleaner separation of concerns.
+  - Better gate-level observability and testing.
+- Negative:
+  - Integration requires stable dispatch contracts from Root/Kernel.
 
 ## Status
 
-Active
+Accepted and active.

--- a/docs/design/adr/ADR-005-mind-proposer.md
+++ b/docs/design/adr/ADR-005-mind-proposer.md
@@ -7,66 +7,45 @@ applies_to:
   runbook: docs/runbooks/mind-redis-stm.md
   phase: v5.3
   anchor: "#phase-mind-proposer"
+law_refs:
+  - deps/yai-specs/contracts/invariants/I-002-determinism.md
+  - deps/yai-specs/contracts/invariants/I-004-cognitive-reconfiguration.md
+  - deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md
+  - deps/yai-specs/contracts/boundaries/L3-mind.md
 ---
-# ADR-005 — Mind Per Workspace (L3 Cognitive Plane)
+# ADR-005 - Mind as Workspace-Scoped Proposer (L3)
 
 ## Context
 
-# YAI Architecture Decisions (Law-Aligned, 2026 Revision)
+Cognitive features need to evolve without becoming a hidden execution authority or a cross-workspace leakage vector.
 
-This document captures the **machine-level architecture commitments**
-of YAI as of the current runtime refactor phase.
+## Decision
 
-It is grounded in `deps/yai-specs/contracts/` invariants and reflects the
-post-envelope, post-authority enforcement state.
-
-The architecture is stratified across:
-
-- L0 — Vault (immutable identity & ABI boundary)
-- L1 — Kernel (authority, sessions, isolation)
-- L2 — Engine (execution gates)
-- L3 — Mind (proposal-only cognition per workspace)
-- Root — Machine Control Plane (runtime governor)
-
----
-
-### Decision
-
-Each workspace owns one Mind instance.
-
-Mind is:
-
-- workspace-scoped
-- proposal-only
-- non-authoritative
+Each workspace owns its Mind context. Mind is proposal-oriented and non-authoritative.
 
 Mind may:
 
-- build graph state
-- generate plans
-- propose actions
+- Build internal graph/cognitive state
+- Generate plans and proposals
 
-Mind may NOT:
+Mind may not:
 
-- execute external effects
-- bypass Engine
-- access other workspaces
+- Execute external effects directly
+- Bypass Engine/Kernel governance
+- Access other workspace state by default
 
-### Rationale
+## Rationale
 
-Preserves:
+This model preserves cognitive isolation while keeping effectful operations under governed L1/L2 control.
 
-- Cognitive isolation
-- Determinism
-- Law invariants
+## Consequences
 
-### Status
-
-Mind remains per-workspace Rust process.
-Future consolidation possible under runtime governance.
-
----
+- Positive:
+  - Safe evolution of cognition features.
+  - Clear boundary between reasoning and execution.
+- Negative:
+  - Additional orchestration needed for proposal-to-execution flows.
 
 ## Status
 
-Active
+Accepted and active.

--- a/docs/design/adr/ADR-006-unified-rpc.md
+++ b/docs/design/adr/ADR-006-unified-rpc.md
@@ -14,62 +14,36 @@ law_refs:
   - deps/yai-specs/contracts/boundaries/L1-kernel.md
   - deps/yai-specs/contracts/boundaries/L2-engine.md
 ---
-# ADR-006 — Strict Unified RPC Contract
+# ADR-006 - Strict Unified RPC Contract
 
 ## Context
 
-Milestone 1 requires one explicit contract baseline across specs, core, and CLI.
-Without a strict mapping between envelope contract and exposed command surface, CI can report green while runtime proofs remain partial.
+Milestone 1 required one explicit envelope and command baseline across specs, core runtime, and CLI. Without this, CI could be green while operational behavior drifted.
 
 ## Decision
 
-All communication follows one binary envelope contract anchored in specs:
+All communication follows the pinned binary contract in `deps/yai-specs`, with command semantics anchored by CLI contract artifacts.
 
-- `deps/yai-specs/specs/protocol/include/transport.h`
-- `deps/yai-specs/specs/protocol/include/protocol.h`
-- `deps/yai-specs/specs/protocol/include/yai_protocol_ids.h`
-- `deps/yai-specs/specs/protocol/include/errors.h`
-- `deps/yai-specs/specs/protocol/include/auth.h`
-- `deps/yai-specs/specs/protocol/include/roles.h`
-- `deps/yai-specs/specs/protocol/include/session.h`
-- `deps/yai-specs/specs/protocol/runtime/include/rpc_runtime.h`
+Mandatory rules:
 
-And command semantics are anchored by pinned CLI contract artifacts:
-
-- `deps/yai-specs/specs/cli/schema/commands.v1.json`
-- `deps/yai-specs/specs/cli/schema/commands.schema.json`
-
-## Mandatory Rules
-
-- Handshake required before effectful commands.
-- `ws_id` required for runtime-bound commands.
-- `arming + role` required for privileged commands.
-- Deterministic reject semantics with stable code mapping to specs.
-- No behavior may be claimed as "proved" if required gates are skipped.
-
-## Prohibited
-
-- Parallel protocol surfaces
-- Out-of-contract side channels
-- CLI shortcuts that bypass contract semantics
-- Green evidence based on mandatory-step `SKIP`
+- Handshake before effectful commands
+- Workspace context for runtime-bound commands
+- Role + arming enforcement for privileged operations
+- Deterministic reject semantics mapped to contract identifiers
+- No mandatory proof claims on skipped gates
 
 ## Rationale
 
-This establishes an auditable baseline for Milestone 1:
+A strict contract baseline makes drift observable and converts gate output into reliable evidence.
 
-- contract and implementation drift are machine-detectable
-- runtime gates can be interpreted as real evidence
-- TRL progression is tied to non-skipped proof
+## Consequences
 
-## Law Alignment
-
-- `deps/yai-specs/contracts/invariants/I-001-traceability.md`
-- `deps/yai-specs/contracts/invariants/I-002-determinism.md`
-- `deps/yai-specs/contracts/invariants/I-003-governance.md`
-- `deps/yai-specs/contracts/boundaries/L1-kernel.md`
-- `deps/yai-specs/contracts/boundaries/L2-engine.md`
+- Positive:
+  - Better parity between law/spec and implementation.
+  - Stronger auditability for TRL progression.
+- Negative:
+  - Tighter CI can increase short-term failures during migration.
 
 ## Status
 
-Active. Milestone 1 requires CI/gates to enforce this contract baseline explicitly.
+Accepted and active.

--- a/docs/design/adr/ADR-007-workspace-isolation.md
+++ b/docs/design/adr/ADR-007-workspace-isolation.md
@@ -7,50 +7,41 @@ applies_to:
   runbook: docs/runbooks/workspaces-lifecycle.md
   phase: 0.1.0
   anchor: "#phase-0-1-0-workspace-layout"
+law_refs:
+  - deps/yai-specs/contracts/invariants/I-001-traceability.md
+  - deps/yai-specs/contracts/invariants/I-002-determinism.md
+  - deps/yai-specs/contracts/boundaries/L1-kernel.md
+  - deps/yai-specs/specs/protocol/include/session.h
+  - deps/yai-specs/specs/protocol/include/transport.h
 ---
-# ADR-007 — Workspace Isolation Model
+# ADR-007 - Workspace Isolation Model
 
 ## Context
 
-# YAI Architecture Decisions (Law-Aligned, 2026 Revision)
+Workspace lifecycle and runtime ownership needed a clear isolation model to prevent session bleed and mixed authority paths.
 
-This document captures the **machine-level architecture commitments**
-of YAI as of the current runtime refactor phase.
+## Decision
 
-It is grounded in `deps/yai-specs/contracts/` invariants and reflects the
-post-envelope, post-authority enforcement state.
+Isolation is enforced on three layers:
 
-The architecture is stratified across:
+1. Session/lock ownership
+2. Per-workspace storage/memory boundaries
+3. Root-mediated routing for runtime commands
 
-- L0 — Vault (immutable identity & ABI boundary)
-- L1 — Kernel (authority, sessions, isolation)
-- L2 — Engine (execution gates)
-- L3 — Mind (proposal-only cognition per workspace)
-- Root — Machine Control Plane (runtime governor)
+Stale lock recovery remains allowed, but only through deterministic validation.
 
----
+## Rationale
 
-### Decision
+The model keeps tenancy explicit and reduces accidental cross-workspace effects under concurrent runtime load.
 
-Workspace isolation is enforced at three levels:
+## Consequences
 
-1. Session lock (PID-based lockfile)
-2. Memory isolation (per-ws storage paths)
-3. RPC routing (Root-bound dispatch)
-
-### Lockfile Policy
-
-- Lockfile contains PID
-- Stale lock detection via kill(pid, 0)
-- Stale locks auto-recovered
-
-### Status
-
-Robust lock logic active.
-Future: move from file-lock to runtime registry model.
-
----
+- Positive:
+  - Safer multi-workspace operation.
+  - Better reproducibility under parallel sessions.
+- Negative:
+  - Operational tooling must preserve strict lock semantics.
 
 ## Status
 
-Active
+Accepted and active.

--- a/docs/design/adr/ADR-008-connection-lifecycle.md
+++ b/docs/design/adr/ADR-008-connection-lifecycle.md
@@ -14,47 +14,38 @@ law_refs:
   - deps/yai-specs/specs/protocol/include/session.h
   - deps/yai-specs/specs/protocol/include/transport.h
 ---
-# ADR-008 — Connection Lifecycle Semantics
+# ADR-008 - Connection Lifecycle Semantics
 
 ## Context
 
-Connection lifecycle must remain deterministic and auditable across Root and workspace-attached sessions.
-Current implementation is partially proven: baseline handshake/lifecycle exists, but full command-surface parity and non-skip gate proof are still incomplete.
+Connection semantics are foundational for deterministic control-plane behavior and must stay consistent across Root and workspace-attached sessions.
 
 ## Decision
 
-Connections are one of:
+Two connection states are supported:
 
-- root session
-- workspace-attached session
+- Root session
+- Workspace-attached session
 
-Handshake establishes protocol validity.
-Attach establishes workspace context.
+Lifecycle rules:
 
-## Rules
-
-- No execution before handshake.
-- No runtime-bound execution before explicit attach/workspace context.
-- Reconnect requires re-handshake.
-- Rejects must be deterministic and trace-correlatable.
+- Handshake is mandatory before execution
+- Workspace attach is mandatory for runtime-bound operations
+- Reconnect requires fresh handshake
+- Reject paths must remain deterministic and traceable
 
 ## Rationale
 
-Lifecycle is the control boundary between contract validity and execution authority.
-Ambiguous status wording in docs can overstate readiness; Milestone 1 needs status language aligned to evidence.
+A strict lifecycle avoids hidden state transitions and improves forensic clarity for failures.
 
-## Law Alignment
+## Consequences
 
-- `deps/yai-specs/contracts/invariants/I-001-traceability.md`
-- `deps/yai-specs/contracts/invariants/I-002-determinism.md`
-- `deps/yai-specs/contracts/invariants/I-003-governance.md`
-- `deps/yai-specs/specs/protocol/include/session.h`
-- `deps/yai-specs/specs/protocol/include/transport.h`
+- Positive:
+  - Cleaner protocol guarantees and stable observability.
+  - Better fit for non-skip proof requirements.
+- Negative:
+  - Partial implementations cannot be presented as full readiness.
 
 ## Status
 
-Active with partial proof coverage:
-
-- handshake and basic lifecycle semantics are implemented in core paths
-- persistent cockpit session model remains pending
-- full non-skip gate evidence for lifecycle claims is still required for higher TRL assertions
+Accepted and active, with remaining evidence hardening tracked in runbook phases.

--- a/docs/design/adr/ADR-009-engine-attachment.md
+++ b/docs/design/adr/ADR-009-engine-attachment.md
@@ -7,50 +7,40 @@ applies_to:
   runbook: docs/runbooks/engine-attach.md
   phase: v4
   anchor: "#phase-engine-attach-v4"
+law_refs:
+  - deps/yai-specs/contracts/invariants/I-003-governance.md
+  - deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md
+  - deps/yai-specs/contracts/boundaries/L1-kernel.md
+  - deps/yai-specs/contracts/boundaries/L2-engine.md
 ---
-# ADR-009 — Engine Attachment Model (Next Phase)
+# ADR-009 - Engine Attachment Model
 
 ## Context
 
-# YAI Architecture Decisions (Law-Aligned, 2026 Revision)
+Current runtime integration still carries transitional wiring. A final attachment model is needed to eliminate per-workspace execution coupling.
 
-This document captures the **machine-level architecture commitments**
-of YAI as of the current runtime refactor phase.
+## Decision
 
-It is grounded in `deps/yai-specs/contracts/` invariants and reflects the
-post-envelope, post-authority enforcement state.
+Engine is attached as a shared runtime plane under Root governance; workspace context is passed through dispatch metadata rather than process topology.
 
-The architecture is stratified across:
+Target model:
 
-- L0 — Vault (immutable identity & ABI boundary)
-- L1 — Kernel (authority, sessions, isolation)
-- L2 — Engine (execution gates)
-- L3 — Mind (proposal-only cognition per workspace)
-- Root — Machine Control Plane (runtime governor)
+- Root governs ingress and routing
+- Kernel enforces authority
+- Engine executes within authorized workspace context
 
----
+## Rationale
 
-### Decision
+Shared attachment improves operability and keeps execution behavior aligned with the single-runtime strategy.
 
-Engine will be attached to Root runtime,
-not directly spawned per workspace.
+## Consequences
 
-Workspace context will be passed through dispatch layer.
-
-### Future Model
-
-Root
- ├── Kernel (authority)
- ├── Engine (shared execution plane)
- └── Workspace contexts (logical isolation)
-
-### Status
-
-Planned.
-Not yet fully integrated.
-
----
+- Positive:
+  - Lower operational complexity.
+  - Cleaner governance boundary from ingress to effects.
+- Negative:
+  - Requires careful migration of existing workspace-oriented assumptions.
 
 ## Status
 
-Active
+Draft; acceptance tied to engine-attach runbook completion.

--- a/docs/design/adr/ADR-010-boot-entrypoint.md
+++ b/docs/design/adr/ADR-010-boot-entrypoint.md
@@ -7,49 +7,43 @@ applies_to:
   runbook: docs/runbooks/root-hardening.md
   phase: boot-baseline
   anchor: "#phase-root-boot-baseline"
+law_refs:
+  - deps/yai-specs/contracts/axioms/A-002-authority.md
+  - deps/yai-specs/contracts/invariants/I-003-governance.md
+  - deps/yai-specs/contracts/boundaries/L1-kernel.md
+  - deps/yai-specs/specs/protocol/include/transport.h
 ---
-# ADR-010 — Boot as Canonical Machine Entry
+# ADR-010 - Boot as Canonical Machine Entry
 
 ## Context
 
-# YAI Architecture Decisions (Law-Aligned, 2026 Revision)
+Multiple startup paths historically allowed inconsistent runtime initialization and reduced confidence in machine-level governance.
 
-This document captures the **machine-level architecture commitments**
-of YAI as of the current runtime refactor phase.
+## Decision
 
-It is grounded in `deps/yai-specs/contracts/` invariants and reflects the
-post-envelope, post-authority enforcement state.
+`yai` boot is the canonical runtime entrypoint.
 
-The architecture is stratified across:
+Boot responsibilities:
 
-- L0 — Vault (immutable identity & ABI boundary)
-- L1 — Kernel (authority, sessions, isolation)
-- L2 — Engine (execution gates)
-- L3 — Mind (proposal-only cognition per workspace)
-- Root — Machine Control Plane (runtime governor)
+- Preboot validation
+- Runtime directory integrity checks
+- Root socket initialization
+- Ordered startup of governed planes
 
----
+Direct ad-hoc startup of internal binaries is deprecated.
 
-### Decision
+## Rationale
 
-`yai` (boot) is the only official runtime entrypoint.
+A single entrypoint improves reproducibility, policy enforcement, and incident diagnosis.
 
-It performs:
+## Consequences
 
-- preboot validation
-- directory integrity
-- root socket creation
-- runtime initialization
-
-Direct launching of workspace kernel binaries is deprecated.
-
-### Status
-
-Migration in progress.
-Boot canonicalization required before engine integration.
-
----
+- Positive:
+  - Consistent startup contract for operators and CI.
+  - Better alignment with Root-first architecture.
+- Negative:
+  - Legacy scripts and habits need migration.
 
 ## Status
 
-Active
+Accepted and active.

--- a/docs/design/adr/ADR-011-contract-baseline-lock.md
+++ b/docs/design/adr/ADR-011-contract-baseline-lock.md
@@ -14,57 +14,39 @@ law_refs:
   - deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md
   - deps/yai-specs/contracts/boundaries/L1-kernel.md
 ---
-# ADR-011 — Contract Baseline Lock for Milestone 1
+# ADR-011 - Contract Baseline Lock for Milestone 1
 
 ## Context
 
-The program needs a stable first milestone before deeper runbook delivery.
-Current evidence shows three risks:
+Milestone 1 exposed three recurring risks:
 
-- specs/CLI command-surface drift,
-- runtime gate success with mandatory-step `SKIP`,
-- uneven proof quality for TRL claims.
-
-Without a baseline lock, refactors in specs can outpace consumers and produce false confidence.
+- Contract drift between specs and CLI/runtime behavior
+- Green pipelines with skipped mandatory proof steps
+- Inconsistent evidence quality for TRL-facing claims
 
 ## Decision
 
-Milestone 1 enforces a Contract Baseline Lock across `yai-specs`, `yai`, and `yai-cli`.
+Milestone 1 enforces a contract baseline lock across `yai-specs`, `yai`, and `yai-cli`.
 
-### Baseline contract scope
+Controls:
 
-- Protocol + runtime headers under `deps/yai-specs/specs/protocol/**`
-- CLI command contract under `deps/yai-specs/specs/cli/schema/**`
-- Error/authority semantics used for deterministic rejects
-
-### Mandatory controls
-
-1. Specs and CLI behavior must be compared in CI (anti-drift).
-2. Required TRL gates must fail when capability is missing (no pass-on-skip for mandatory steps).
-3. Verify-core and formal checks must be updated when contract deltas affect invariants/authority/envelope semantics.
-4. Cross-repo pins remain explicit and auditable.
+1. CI parity checks between pinned specs contract and CLI/runtime behavior
+2. Mandatory gates fail on missing capability (no pass-on-skip)
+3. Formal/core verify updates are required when contract deltas affect authority/envelope invariants
+4. Cross-repo pins remain explicit and auditable
 
 ## Rationale
 
-This creates a dependable execution base for subsequent runbook phases (root hardening, workspaces, engine attach) and enables evidence-driven TRL progression.
+A lock provides a stable legal/technical floor so later runbook phases can evolve without losing evidence integrity.
 
 ## Consequences
 
 - Positive:
-  - Refactors can proceed with controlled blast radius.
-  - Evidence quality improves (less ambiguity between "implemented" and "proved").
+  - Stronger confidence in cross-repo compatibility.
+  - Better audit quality and clearer TRL narrative.
 - Negative:
-  - Short-term CI strictness may initially increase failures.
-  - Requires coordinated updates across repos for contract-touching changes.
-
-## Law Alignment
-
-- `deps/yai-specs/contracts/invariants/I-001-traceability.md`
-- `deps/yai-specs/contracts/invariants/I-002-determinism.md`
-- `deps/yai-specs/contracts/invariants/I-003-governance.md`
-- `deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md`
-- `deps/yai-specs/contracts/boundaries/L1-kernel.md`
+  - Higher short-term coordination cost for contract-touching changes.
 
 ## Status
 
-Draft (to be accepted with Milestone 1 kickoff).
+Draft; intended for acceptance at Milestone 1 governance kickoff.


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): Maintainer-requested ADR alignment pass; no pre-existing issue.
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: 5aa7ebde713d9938c215a09dfa385e05c35c7161

## Classification
- Classification: DOCS
- Compatibility: A

## Objective
Align ADR 001-011 with valid law_refs and concise, consistent wording.

## Docs touched
- docs/design/adr/ADR-001-single-runtime.md
- docs/design/adr/ADR-002-root-entrypoint.md
- docs/design/adr/ADR-003-kernel-authority.md
- docs/design/adr/ADR-004-engine-execution.md
- docs/design/adr/ADR-005-mind-proposer.md
- docs/design/adr/ADR-006-unified-rpc.md
- docs/design/adr/ADR-007-workspace-isolation.md
- docs/design/adr/ADR-008-connection-lifecycle.md
- docs/design/adr/ADR-009-engine-attachment.md
- docs/design/adr/ADR-010-boot-entrypoint.md
- docs/design/adr/ADR-011-contract-baseline-lock.md

## Spec/Contract delta
- No spec/contract change; documentation-only ADR alignment.

## Evidence
- Positive:
  - make docs-verify no longer reports ADR errors
- Negative:
  - make docs-verify still fails on runbooks/milestone packs (out of scope)

## Commands run
```bash
make docs-verify
```

## Checklist
- [x] No broken links
- [x] Templates updated consistently (if touched)
- [x] Doc aligns with current repo state (no "future tense" lying)
