### PR TITLE
docs(design): add proposal baseline and traceability alignment

### DIFF
--- a/docs/design/proposals/PRP-001-runtime-topology-and-authority.md
+++ b/docs/design/proposals/PRP-001-runtime-topology-and-authority.md
@@ -1,0 +1,66 @@
+---
+id: PRP-001
+title: Runtime topology and authority boundaries
+status: draft
+owner: core-architecture
+effective_date: 2026-02-19
+revision: 1
+supersedes: []
+related:
+  adr:
+    - docs/design/adr/ADR-001-single-runtime.md
+    - docs/design/adr/ADR-002-root-entrypoint.md
+    - docs/design/adr/ADR-003-kernel-authority.md
+    - docs/design/adr/ADR-004-engine-execution.md
+    - docs/design/adr/ADR-005-mind-proposer.md
+  runbooks:
+    - docs/runbooks/root-hardening.md
+  specs:
+    - deps/yai-specs/contracts/axioms/A-002-authority.md
+    - deps/yai-specs/contracts/boundaries/L1-kernel.md
+    - deps/yai-specs/contracts/boundaries/L2-engine.md
+tags:
+  - topology
+  - authority
+  - runtime
+---
+
+# PRP-001 - Runtime topology and authority boundaries
+
+## Problem
+Architecture decisions around runtime scope and authority are spread across multiple ADRs. The project needs one pre-decision framing that explains why a machine-level runtime is preferred and how authority boundaries are enforced end-to-end.
+
+## Scope
+- In scope: Runtime topology options, authority plane boundaries, workspace-to-runtime routing model.
+- Out of scope: Protocol wire-format details and CLI command taxonomy.
+
+## Proposed Change
+Define and document the rationale for one machine-level runtime with strict Root -> Kernel -> Engine authority flow and workspace isolation by design.
+
+## Options Compared
+- Option A: Single machine-level runtime with multi-workspace routing.
+- Option B: Per-workspace daemon model with coordination layer.
+
+## Risks
+- Migration complexity from workspace-first habits. Mitigation: phased rollout through runbook phases.
+- Confusion on authority ownership. Mitigation: explicit law anchors and boundary diagrams.
+
+## Rollout Sketch
+1. Publish topology proposal with explicit L0 anchors.
+2. Confirm ADR mapping set (001..005).
+3. Gate implementation phases through root-hardening milestones.
+
+## Exit Criteria
+- [ ] Proposal clearly maps alternatives and selects a preferred topology.
+- [ ] Law anchors for authority boundaries are explicit and complete.
+- [ ] Target ADR set is confirmed and linked.
+
+## Traceability
+
+- Spec anchors (if any): `deps/yai-specs/contracts/axioms/A-002-authority.md`, `deps/yai-specs/contracts/boundaries/L1-kernel.md`, `deps/yai-specs/contracts/boundaries/L2-engine.md`
+- Targets ADR: `docs/design/adr/ADR-001-single-runtime.md`, `docs/design/adr/ADR-002-root-entrypoint.md`, `docs/design/adr/ADR-003-kernel-authority.md`, `docs/design/adr/ADR-004-engine-execution.md`, `docs/design/adr/ADR-005-mind-proposer.md`
+
+## References
+- `docs/design/spine.md`
+- `docs/design/traceability.md`
+- `docs/design/adr/ADR-001-single-runtime.md`

--- a/docs/design/proposals/PRP-002-unified-rpc-and-cli-contract.md
+++ b/docs/design/proposals/PRP-002-unified-rpc-and-cli-contract.md
@@ -1,0 +1,65 @@
+---
+id: PRP-002
+title: Unified RPC envelope and CLI contract alignment
+status: draft
+owner: core-protocol
+effective_date: 2026-02-19
+revision: 1
+supersedes: []
+related:
+  adr:
+    - docs/design/adr/ADR-006-unified-rpc.md
+    - docs/design/adr/ADR-011-contract-baseline-lock.md
+  runbooks:
+    - docs/runbooks/root-hardening.md
+  specs:
+    - deps/yai-specs/specs/protocol/include/transport.h
+    - deps/yai-specs/specs/protocol/include/protocol.h
+    - deps/yai-specs/specs/protocol/runtime/include/rpc_runtime.h
+    - deps/yai-specs/specs/cli/schema/commands.v1.json
+tags:
+  - rpc
+  - cli
+  - contract
+  - anti-drift
+---
+
+# PRP-002 - Unified RPC envelope and CLI contract alignment
+
+## Problem
+Contract drift between protocol/runtime headers and CLI command definitions can produce green CI with incomplete semantic alignment.
+
+## Scope
+- In scope: Envelope contract, command-surface alignment, deterministic reject semantics, anti-drift controls.
+- Out of scope: Workspace lifecycle internals and engine attach strategy.
+
+## Proposed Change
+Adopt one canonical RPC surface and enforce CLI-to-spec alignment through explicit baseline checks and mandatory non-skip gate policy.
+
+## Options Compared
+- Option A: Strict single-surface contract with CI anti-drift enforcement.
+- Option B: Multi-surface transition period with compatibility adapters.
+
+## Risks
+- Short-term CI noise due to stricter checks. Mitigation: phased enforcement with visible failure taxonomy.
+- Cross-repo sync overhead. Mitigation: pin policy and sync scripts.
+
+## Rollout Sketch
+1. Freeze baseline artifact list.
+2. Add contract comparison checks in CI.
+3. Enforce deterministic reject matrix for mandatory steps.
+
+## Exit Criteria
+- [ ] Baseline artifact list is explicit and versioned.
+- [ ] CI detects spec/CLI drift deterministically.
+- [ ] Mandatory gates fail on missing capability (no pass-on-skip).
+
+## Traceability
+
+- Spec anchors (if any): `deps/yai-specs/specs/protocol/include/transport.h`, `deps/yai-specs/specs/protocol/include/protocol.h`, `deps/yai-specs/specs/protocol/runtime/include/rpc_runtime.h`, `deps/yai-specs/specs/cli/schema/commands.v1.json`
+- Targets ADR: `docs/design/adr/ADR-006-unified-rpc.md`, `docs/design/adr/ADR-011-contract-baseline-lock.md`
+
+## References
+- `docs/design/spine.md`
+- `docs/design/adr/ADR-006-unified-rpc.md`
+- `docs/design/adr/ADR-011-contract-baseline-lock.md`

--- a/docs/design/proposals/PRP-003-workspace-lifecycle-and-isolation.md
+++ b/docs/design/proposals/PRP-003-workspace-lifecycle-and-isolation.md
@@ -1,0 +1,66 @@
+---
+id: PRP-003
+title: Workspace lifecycle and isolation guarantees
+status: draft
+owner: runtime-kernel
+effective_date: 2026-02-19
+revision: 1
+supersedes: []
+related:
+  adr:
+    - docs/design/adr/ADR-007-workspace-isolation.md
+    - docs/design/adr/ADR-008-connection-lifecycle.md
+    - docs/design/adr/ADR-009-engine-attachment.md
+    - docs/design/adr/ADR-010-boot-entrypoint.md
+  runbooks:
+    - docs/runbooks/workspaces-lifecycle.md
+  specs:
+    - deps/yai-specs/contracts/boundaries/L1-kernel.md
+    - deps/yai-specs/specs/protocol/include/session.h
+    - deps/yai-specs/contracts/invariants/I-002-determinism.md
+    - deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md
+tags:
+  - workspace
+  - isolation
+  - lifecycle
+---
+
+# PRP-003 - Workspace lifecycle and isolation guarantees
+
+## Problem
+Workspace lifecycle behavior is currently captured at ADR level but lacks a consolidated pre-decision analysis that spans lock, connection lifecycle, boot/attach flow, and runtime routing.
+
+## Scope
+- In scope: Workspace lock semantics, connection lifecycle, attach/boot boundaries, routing constraints.
+- Out of scope: Protocol envelope fields and formal-coverage expansion.
+
+## Proposed Change
+Define one lifecycle proposal that aligns isolation guarantees with Kernel boundary rules and explicitly traces lifecycle states to contract invariants.
+
+## Options Compared
+- Option A: Lockfile-first lifecycle with incremental runtime registry transition.
+- Option B: Immediate runtime-registry lifecycle with lockfiles deprecated.
+
+## Risks
+- Race conditions in transition path. Mitigation: explicit state machine and deterministic reject tests.
+- Operator confusion during mixed mode. Mitigation: docs and runbook acceptance checks.
+
+## Rollout Sketch
+1. Define lifecycle states and invalid transitions.
+2. Map each transition to spec/invariant anchors.
+3. Gate rollout with workspace lifecycle runbook phases.
+
+## Exit Criteria
+- [ ] Lifecycle state model is documented with valid/invalid transitions.
+- [ ] Isolation guarantees are mapped to boundary and invariant anchors.
+- [ ] ADR mapping set (007..010) is explicit.
+
+## Traceability
+
+- Spec anchors (if any): `deps/yai-specs/contracts/boundaries/L1-kernel.md`, `deps/yai-specs/specs/protocol/include/session.h`, `deps/yai-specs/contracts/invariants/I-002-determinism.md`, `deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md`
+- Targets ADR: `docs/design/adr/ADR-007-workspace-isolation.md`, `docs/design/adr/ADR-008-connection-lifecycle.md`, `docs/design/adr/ADR-009-engine-attachment.md`, `docs/design/adr/ADR-010-boot-entrypoint.md`
+
+## References
+- `docs/design/spine.md`
+- `docs/design/adr/ADR-007-workspace-isolation.md`
+- `docs/design/adr/ADR-008-connection-lifecycle.md`

--- a/docs/design/proposals/PRP-004-contract-baseline-lock-and-pin-policy.md
+++ b/docs/design/proposals/PRP-004-contract-baseline-lock-and-pin-policy.md
@@ -1,0 +1,64 @@
+---
+id: PRP-004
+title: Contract baseline lock and cross-repo pin policy
+status: draft
+owner: release-governance
+effective_date: 2026-02-19
+revision: 1
+supersedes: []
+related:
+  adr:
+    - docs/design/adr/ADR-011-contract-baseline-lock.md
+  runbooks:
+    - docs/runbooks/root-hardening.md
+  specs:
+    - deps/yai-specs/formal/traceability.v1.json
+    - deps/yai-specs/formal/spec_map.md
+    - deps/yai-specs/contracts/invariants/I-001-traceability.md
+    - deps/yai-specs/contracts/invariants/I-007-compliance-context-required.md
+tags:
+  - baseline
+  - pin
+  - governance
+  - ci
+---
+
+# PRP-004 - Contract baseline lock and cross-repo pin policy
+
+## Problem
+Cross-repo updates can become inconsistent when pins are not updated in lockstep with contract changes, reducing trust in evidence and delivery claims.
+
+## Scope
+- In scope: Baseline definition, pin update rules, CI anti-drift gates, cross-repo coordination points.
+- Out of scope: Detailed runtime topology and per-command behavior.
+
+## Proposed Change
+Define a formal baseline-lock policy with explicit pin responsibilities for `yai`, `yai-cli`, and `yai-specs`, including required checks before milestone closure.
+
+## Options Compared
+- Option A: Strict lockstep pin policy with mandatory checks.
+- Option B: Soft pin policy with best-effort sync windows.
+
+## Risks
+- Coordination cost across repos. Mitigation: scripted sync + clear owner model.
+- Slower merge velocity for contract-touching changes. Mitigation: narrow baseline scopes per milestone.
+
+## Rollout Sketch
+1. Define baseline contract manifest.
+2. Define owner/responsibility matrix for pin updates.
+3. Enforce checks before merge on contract-touching PRs.
+
+## Exit Criteria
+- [ ] Pin policy is explicit for each consumer repo.
+- [ ] Mandatory pre-merge checks are documented.
+- [ ] ADR-011 acceptance criteria can reference this proposal directly.
+
+## Traceability
+
+- Spec anchors (if any): `deps/yai-specs/formal/traceability.v1.json`, `deps/yai-specs/formal/spec_map.md`, `deps/yai-specs/contracts/invariants/I-001-traceability.md`, `deps/yai-specs/contracts/invariants/I-007-compliance-context-required.md`
+- Targets ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+
+## References
+- `docs/design/spine.md`
+- `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- `tools/release/sync_specs_refs.sh`

--- a/docs/design/proposals/PRP-005-formal-coverage-roadmap.md
+++ b/docs/design/proposals/PRP-005-formal-coverage-roadmap.md
@@ -1,0 +1,63 @@
+---
+id: PRP-005
+title: Formal coverage roadmap for spec-critical domains
+status: draft
+owner: formal-methods
+effective_date: 2026-02-19
+revision: 1
+supersedes: []
+related:
+  adr:
+    - docs/design/adr/ADR-006-unified-rpc.md
+    - docs/design/adr/ADR-011-contract-baseline-lock.md
+  runbooks: []
+  specs:
+    - deps/yai-specs/formal/spec_map.md
+    - deps/yai-specs/formal/tla/YAI_KERNEL.tla
+    - deps/yai-specs/formal/bindings/BINDING_PROTOCOL.md
+    - deps/yai-specs/formal/bindings/BINDING_CLI.md
+tags:
+  - formal
+  - roadmap
+  - coverage
+---
+
+# PRP-005 - Formal coverage roadmap for spec-critical domains
+
+## Problem
+Current formal coverage is uneven across domains. Some areas are modeled while others remain smoke/none, which limits confidence for stronger TRL claims.
+
+## Scope
+- In scope: Coverage priorities, domain gap list, staged property roadmap, evidence expectations.
+- Out of scope: Rewriting the whole TLA model in one phase.
+
+## Proposed Change
+Define a prioritized formal roadmap that starts from protocol/control criticality, then addresses CLI, vault, and graph gaps with explicit property targets.
+
+## Options Compared
+- Option A: Risk-first roadmap based on invariant and boundary criticality.
+- Option B: Surface-first roadmap by component ownership.
+
+## Risks
+- Over-expansion of formal scope. Mitigation: milestone-based slices with hard acceptance criteria.
+- Weak adoption if disconnected from delivery gates. Mitigation: link roadmap outputs to CI and milestone packs.
+
+## Rollout Sketch
+1. Publish current modeled/smoke/none matrix.
+2. Select next two domains for explicit property additions.
+3. Bind roadmap outputs to release evidence expectations.
+
+## Exit Criteria
+- [ ] Coverage matrix and priority order are explicit.
+- [ ] Next formal increments define target properties and artifacts.
+- [ ] Proposal links to ADR and milestone evidence strategy.
+
+## Traceability
+
+- Spec anchors (if any): `deps/yai-specs/formal/spec_map.md`, `deps/yai-specs/formal/tla/YAI_KERNEL.tla`, `deps/yai-specs/formal/bindings/BINDING_PROTOCOL.md`, `deps/yai-specs/formal/bindings/BINDING_CLI.md`
+- Targets ADR: `docs/design/adr/ADR-006-unified-rpc.md`, `docs/design/adr/ADR-011-contract-baseline-lock.md`
+
+## References
+- `docs/design/spine.md`
+- `deps/yai-specs/formal/spec_map.md`
+- `deps/yai-specs/formal/traceability.v1.json`

--- a/docs/design/proposals/README.md
+++ b/docs/design/proposals/README.md
@@ -14,6 +14,19 @@ They are used when we need structured exploration before freezing an ADR.
 
 - `docs/templates/proposals/PRP-000-template.md`
 
+## Current proposal set
+
+- `docs/design/proposals/PRP-001-runtime-topology-and-authority.md`
+  Runtime topology and authority boundaries (feeds ADR-001..ADR-005).
+- `docs/design/proposals/PRP-002-unified-rpc-and-cli-contract.md`
+  Unified RPC envelope and CLI contract alignment (feeds ADR-006, ADR-011).
+- `docs/design/proposals/PRP-003-workspace-lifecycle-and-isolation.md`
+  Workspace lifecycle and isolation guarantees (feeds ADR-007..ADR-010).
+- `docs/design/proposals/PRP-004-contract-baseline-lock-and-pin-policy.md`
+  Contract baseline lock and cross-repo pin policy (feeds ADR-011).
+- `docs/design/proposals/PRP-005-formal-coverage-roadmap.md`
+  Formal coverage roadmap for spec-critical domains (supports contract-proof alignment).
+
 ## Relationship with ADRs
 
 - Proposal: exploration and option analysis.

--- a/docs/design/traceability.md
+++ b/docs/design/traceability.md
@@ -1,20 +1,30 @@
 # Traceability Map
 
-This is the navigable index that prevents “docs drift”.
-It maps frozen decisions and delivery artifacts to their proof.
+This is the navigable index that prevents docs drift.
+It maps proposal and decision artifacts to contract anchors and delivery evidence.
 
 ## How to use this map
-- Add a row when a new ADR or Runbook is introduced.
-- Add MP rows as you ship phases.
-- Keep links as **repo-relative paths** (no external URLs required).
+- Add a row when a new Proposal, ADR, or Runbook is introduced.
+- Keep links as repo-relative paths.
+- Anchor every row to real `deps/yai-specs` paths.
 
-## Map (fill over time)
+## Proposal to ADR map
 
-| Capability / Track | Spec anchors (L0) | ADR (L3) | Runbook (L4) | MP (L5) | Tests / Evidence (L6) |
-|---|---|---|---|---|---|
-| Root hardening | `deps/yai-specs/specs/protocol/include/transport.h`<br/>`deps/yai-specs/specs/protocol/include/errors.h` | `docs/design/adr/ADR-006-unified-rpc.md` *(example)* | `docs/runbooks/root-hardening.md` | `docs/milestone-packs/root-hardening/MP-ROOT-HARDENING-0.1.0.md` | `docs/test-plans/*` + CI logs + runbook commands |
-| Workspaces lifecycle | `deps/yai-specs/contracts/boundaries/L1-kernel.md` | `docs/design/adr/ADR-007-workspace-isolation.md` *(example)* | `docs/runbooks/workspaces-lifecycle.md` | *(TBD)* | *(TBD)* |
+| Proposal (L2) | Spec anchors (L0) | Target ADRs (L3) |
+|---|---|---|
+| `docs/design/proposals/PRP-001-runtime-topology-and-authority.md` | `deps/yai-specs/contracts/axioms/A-002-authority.md`<br/>`deps/yai-specs/contracts/boundaries/L1-kernel.md`<br/>`deps/yai-specs/contracts/boundaries/L2-engine.md` | `docs/design/adr/ADR-001-single-runtime.md`<br/>`docs/design/adr/ADR-002-root-entrypoint.md`<br/>`docs/design/adr/ADR-003-kernel-authority.md`<br/>`docs/design/adr/ADR-004-engine-execution.md`<br/>`docs/design/adr/ADR-005-mind-proposer.md` |
+| `docs/design/proposals/PRP-002-unified-rpc-and-cli-contract.md` | `deps/yai-specs/specs/protocol/include/transport.h`<br/>`deps/yai-specs/specs/protocol/include/protocol.h`<br/>`deps/yai-specs/specs/protocol/runtime/include/rpc_runtime.h`<br/>`deps/yai-specs/specs/cli/schema/commands.v1.json` | `docs/design/adr/ADR-006-unified-rpc.md`<br/>`docs/design/adr/ADR-011-contract-baseline-lock.md` |
+| `docs/design/proposals/PRP-003-workspace-lifecycle-and-isolation.md` | `deps/yai-specs/contracts/boundaries/L1-kernel.md`<br/>`deps/yai-specs/specs/protocol/include/session.h`<br/>`deps/yai-specs/contracts/invariants/I-002-determinism.md`<br/>`deps/yai-specs/contracts/invariants/I-006-external-effect-boundary.md` | `docs/design/adr/ADR-007-workspace-isolation.md`<br/>`docs/design/adr/ADR-008-connection-lifecycle.md`<br/>`docs/design/adr/ADR-009-engine-attachment.md`<br/>`docs/design/adr/ADR-010-boot-entrypoint.md` |
+| `docs/design/proposals/PRP-004-contract-baseline-lock-and-pin-policy.md` | `deps/yai-specs/formal/traceability.v1.json`<br/>`deps/yai-specs/formal/spec_map.md`<br/>`deps/yai-specs/contracts/invariants/I-001-traceability.md`<br/>`deps/yai-specs/contracts/invariants/I-007-compliance-context-required.md` | `docs/design/adr/ADR-011-contract-baseline-lock.md` |
+| `docs/design/proposals/PRP-005-formal-coverage-roadmap.md` | `deps/yai-specs/formal/spec_map.md`<br/>`deps/yai-specs/formal/tla/YAI_KERNEL.tla`<br/>`deps/yai-specs/formal/bindings/BINDING_PROTOCOL.md`<br/>`deps/yai-specs/formal/bindings/BINDING_CLI.md` | `docs/design/adr/ADR-006-unified-rpc.md`<br/>`docs/design/adr/ADR-011-contract-baseline-lock.md` |
+
+## ADR to delivery map
+
+| Capability / Track | ADR (L3) | Runbook (L4) | MP (L5) | Tests / Evidence (L6) |
+|---|---|---|---|---|
+| Root hardening | `docs/design/adr/ADR-006-unified-rpc.md` | `docs/runbooks/root-hardening.md` | `docs/milestone-packs/root-hardening/MP-ROOT-HARDENING-0.1.0.md` | `docs/test-plans/*` + CI logs + runbook commands |
+| Workspaces lifecycle | `docs/design/adr/ADR-007-workspace-isolation.md` | `docs/runbooks/workspaces-lifecycle.md` | *(TBD)* | *(TBD)* |
 
 Notes:
-- Examples above are placeholders. Update paths if they differ in your repo.
+- Keep this map synchronized whenever proposal scope or ADR targets change.
 - Do not invent new anchors: always anchor to `deps/yai-specs` paths.


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): Docs governance/proposal alignment without behavior change
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: 3162648baafca392aea65bfb1fecbea5c625b048

## Classification
- Classification: DOCS
- Compatibility: A

## Objective
Introduce a proposal baseline between spine/traceability and ADR tracks, with explicit L0 anchors for design governance.

## Docs touched
- docs/design/proposals/README.md
- docs/design/traceability.md
- docs/design/proposals/PRP-001-runtime-topology-and-authority.md
- docs/design/proposals/PRP-002-unified-rpc-and-cli-contract.md
- docs/design/proposals/PRP-003-workspace-lifecycle-and-isolation.md
- docs/design/proposals/PRP-004-contract-baseline-lock-and-pin-policy.md
- docs/design/proposals/PRP-005-formal-coverage-roadmap.md

## Spec/Contract delta
- No L0 contract/spec artifacts changed in this PR; only design docs and traceability mapping were updated.

## Evidence
- Positive:
  - All five proposal files are present and linked in docs/design/proposals/README.md.
  - Traceability map now includes proposal-to-L0-anchor-to-ADR mapping.
- Negative:
  - No runtime/core/CLI code paths were modified.
  - No behavior or protocol semantics were changed by this PR.

## Commands run
```bash
git status -sb
ls docs/design/proposals
sed -n '1,220p' docs/design/proposals/README.md
sed -n '1,260p' docs/design/traceability.md
```

## Checklist
- [x] No broken links
- [x] Templates updated consistently (if touched)
- [x] Doc aligns with current repo state (no "future tense" lying)
