### PR TITLE
ci(github): enable automatic PR labels via labeler

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,19 @@
+name: auto-label-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from .github/labeler.yml
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): auto-labeler-workflow
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: bcf0d15c4611a048a7cf42d2ac6415aa4e77bca4

## Classification
- Classification: OPS
- Compatibility: A

## Objective
Enable automatic PR labeling from .github/labeler.yml via GitHub Actions

## Docs touched
- .github/workflows/auto-label-pr.yml
- .github/labeler.yml

## Spec/Contract delta
- No contract/spec/runtime behavior changes
- PR governance metadata improves with automatic labels on PR events

## Evidence
- Positive:
  - Workflow uses actions/labeler@v5 with sync-labels=true
- Negative:
  - N/A

## Commands run
```bash
gh workflow list
```

## Checklist
- [ ] No broken links
- [ ] Templates updated consistently (if touched)
- [ ] Doc aligns with current repo state (no "future tense" lying)
