### PR TITLE
chore(ci): auto-sync project status on PR close

### DIFF
--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -1,0 +1,14 @@
+name: project-status-sync
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  sync:
+    uses: yai-labs/yai-infra/.github/workflows/reusable-project-status-sync.yml@main
+    with:
+      project_owner: yai-labs
+      project_number: 5
+    secrets:
+      project_token: ${{ secrets.YAI_PROJECT_TOKEN }}


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): Cross-repo automation tracked in yai-infra#10; local repo has no dedicated runtime issue.
- Closes-Issue: N/A
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: 6dcdbdc409506de12fbac4617cfa0b6e83708951

## Issue linkage
- Closes N/A

## Classification
- Classification: OPS
- Compatibility: A

## Objective
Enable automatic project status sync on PR close by delegating to yai-infra reusable workflow.

## Docs touched
- .github/workflows/project-status-sync.yml

## Spec/Contract delta
- No spec/contract delta; docs/governance update only.

## Evidence
- Positive:
  - Workflow triggers on pull_request.closed and calls yai-infra reusable sync.
  - No runtime C paths are touched.
- Negative:
  - No source/runtime files under boot/root/kernel/engine/mind/runtime/law changed.

## Commands run
```bash
git diff --name-status origin/main HEAD
tools/bin/yai-pr-check /tmp/pr134-body.md
```

## Checklist
- [x] Issue linkage valid (`N/A` + reason)
- [x] Evidence is concrete (positive: 2, negative: 1)
- [x] Commands are listed and runnable (2)
- [x] Docs touched is explicit (1)
- [x] Spec/contract delta is explicit (1)
- [ ] Link/alignment validation command included
