### PR TITLE
chore(ci): consume yai-infra reusable governance workflows

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -4,16 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   label:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Apply labels from .github/labeler.yml
-        uses: actions/labeler@v5
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          sync-labels: true
+    uses: yai-labs/yai-infra/.github/workflows/reusable-auto-label-pr.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-issue-enforcement.yml
+++ b/.github/workflows/pr-issue-enforcement.yml
@@ -4,73 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   enforce:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Enforce issue linkage policy
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const body = pr.body || "";
-            const { data: fullPr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-            });
-            const labels = (fullPr.labels || []).map((l) => l.name || "");
-
-            const classificationMatch = body.match(/Classification:\s*([A-Z]+)/i);
-            const classification = classificationMatch ? classificationMatch[1].toUpperCase() : "";
-
-            const hasDocsLabel = labels.includes("type:docs") || labels.includes("work-type:docs");
-            const hasCiLabel = labels.includes("type:ci") || labels.includes("work-type:ci");
-            const docsExempt = hasDocsLabel && classification === "DOCS";
-            const ciExempt = hasCiLabel;
-
-            if (docsExempt || ciExempt) {
-              core.info(
-                `Issue-link enforcement skipped due to exemption: docsExempt=${docsExempt}, ciExempt=${ciExempt}`
-              );
-              return;
-            }
-
-            // Accepts Closes/Fixes/Resolves #123 anywhere in body.
-            const hasClosingRef = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+\b/i.test(body);
-            const closingRefMatch = body.match(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/i);
-            const closingIssueNum = closingRefMatch ? closingRefMatch[1] : "";
-
-            // Optional, non-blocking visibility: detect Issue-ID in body.
-            const issueIdMatch = body.match(/Issue-ID:\s*#?(\d+)/i);
-            const hasIssueId = !!issueIdMatch;
-            const issueIdNum = hasIssueId ? issueIdMatch[1] : "";
-
-            // Accept explicit rationale when no auto-closing link is provided.
-            const issueReasonMatch = body.match(/Issue-Reason[^:\n\r]*:\s*([^\n\r]+)/i);
-            const issueReason = issueReasonMatch ? issueReasonMatch[1].trim() : "";
-            const hasIssueReason =
-              issueReason.length > 0 &&
-              !/^<.*>$/.test(issueReason) &&
-              !/^N\/A$/i.test(issueReason) &&
-              !/^(todo|tbd)$/i.test(issueReason);
-
-            if (hasClosingRef || hasIssueReason) {
-              if (hasIssueId && closingIssueNum && issueIdNum !== closingIssueNum) {
-                core.warning(
-                  `Issue-ID (#${issueIdNum}) and closing reference (#${closingIssueNum}) differ.`
-                );
-              }
-              core.info(
-                `Issue-link policy satisfied: hasClosingRef=${hasClosingRef}, hasIssueReason=${hasIssueReason}`
-              );
-              return;
-            }
-
-            core.setFailed(
-              "PR must include either an auto-closing reference (e.g. `Closes #123`) or a non-empty `Issue-Reason:`."
-            );
+    uses: yai-labs/yai-infra/.github/workflows/reusable-pr-issue-enforcement.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-milestone-sync.yml
+++ b/.github/workflows/pr-milestone-sync.yml
@@ -4,64 +4,7 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  contents: read
-  issues: read
-  pull-requests: write
-
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Sync PR milestone from linked issue
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const pr = context.payload.pull_request;
-            const body = pr.body || "";
-
-            // Supports:
-            // - Closes #123 / Fixes #123 / Resolves #123
-            // - full issue URLs
-            const issueRefs = new Set();
-            const closeRe = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:#(\d+)|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+))/gi;
-            let m;
-            while ((m = closeRe.exec(body)) !== null) {
-              const n = m[1] || m[2];
-              if (n) issueRefs.add(Number(n));
-            }
-
-            if (issueRefs.size === 0) {
-              core.info("No closing issue reference found in PR body; skipping milestone sync.");
-              return;
-            }
-
-            const issueNumber = [...issueRefs][0];
-            core.info(`Using linked issue #${issueNumber} for milestone sync`);
-
-            const { data: issue } = await github.rest.issues.get({
-              owner,
-              repo,
-              issue_number: issueNumber,
-            });
-
-            if (!issue.milestone) {
-              core.info(`Issue #${issueNumber} has no milestone; skipping milestone sync.`);
-              return;
-            }
-
-            const targetMilestone = issue.milestone.number;
-            const currentMilestone = pr.milestone ? pr.milestone.number : null;
-            if (currentMilestone === targetMilestone) {
-              core.info(`PR milestone already aligned to '${issue.milestone.title}'.`);
-            } else {
-              await github.rest.issues.update({
-                owner,
-                repo,
-                issue_number: pr.number,
-                milestone: targetMilestone,
-              });
-              core.info(`PR milestone set to '${issue.milestone.title}' from issue #${issueNumber}.`);
-            }
+    uses: yai-labs/yai-infra/.github/workflows/reusable-pr-milestone-sync.yml@main
+    secrets: inherit


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): Cross-repo workflow extraction tracked in yai-labs/yai-infra#31
- Closes-Issue: N/A
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: b4450ec7739c5ded0879194374e31025f967c657

## Issue linkage
- Closes N/A

## Classification
- Classification: OPS
- Compatibility: B

## Objective
Replace local governance workflows with yai-infra reusable callers (auto-label, issue-enforcement, milestone-sync)

## Evidence
- Positive:
  - Baseline commit verified: yai + yai-cli -> 51f0ef3b5985d9fbd18c8f794d03206055bc7f0d
  - git status -sb exit code = 0 (to be confirmed in CI/local run)
- Negative:
  - No runtime/protocol behavior change expected.

## Commands run
```bash
git status -sb
```

## Checklist
- [x] Issue linkage valid (`N/A` + reason)
- [x] Evidence is concrete (positive: 2, negative: 1)
- [x] Commands are listed and runnable (1)

## Cross-repo tracking
- Refs yai-labs/yai-infra#31
