### PR TITLE
docs(schemas): consume canonical schema ownership from yai-infra

### DIFF
--- a/tools/schemas/docs/README.md
+++ b/tools/schemas/docs/README.md
@@ -1,0 +1,9 @@
+# Docs Schemas (Mirror)
+
+This directory is a mirrored copy consumed by local validators in `yai`.
+
+Canonical source is in:
+- `yai-infra/tools/schemas/docs/`
+
+Do not evolve schema contracts directly in this repo.
+Update canonical schemas in `yai-infra` and sync back here.


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): Schema canonicalization tracked in yai-labs/yai-infra#33
- Closes-Issue: N/A
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: 91e57e5e2ab1b22def9d4d2a74a5b4104f5897da

## Issue linkage
- Closes N/A

## Classification
- Classification: DOCS
- Compatibility: B

## Objective
Mark yai docs schemas as mirrored copies with canonical ownership in yai-infra

## Evidence
- Positive:
  - Baseline commit verified: yai + yai-cli -> 51f0ef3b5985d9fbd18c8f794d03206055bc7f0d
  - git status -sb exit code = 0 (to be confirmed in CI/local run)
- Negative:
  - No runtime/protocol behavior change expected.

## Commands run
```bash
git status -sb
```

## Checklist
- [x] Issue linkage valid (`N/A` + reason)
- [x] Evidence is concrete (positive: 2, negative: 1)
- [x] Commands are listed and runnable (1)

## Cross-repo tracking
- Refs yai-labs/yai-infra#33
