### PR TITLE
docs(tooling): consume canonical tooling ownership from yai-infra

### DIFF
--- a/tools/bin/README.md
+++ b/tools/bin/README.md
@@ -1,47 +1,9 @@
-# tools/bin
+# tools/bin (Mirror)
 
-Canonical entrypoints for operational tooling.
+This directory is mirrored for compatibility.
 
-## Purpose
+Canonical governance tooling lives in:
+- `yai-infra/tools/bin/`
 
-Provide stable, easy-to-remember commands for verify, gate, suite, diagnostics, and PR/issue workflow helpers.
-
-## Commands
-
-- `yai-verify`: runs checks from `tools/ops/verify/`.
-- `yai-gate`: runs gates from `tools/ops/gate/`.
-- `yai-suite`: runs suites from `tools/ops/suite/`.
-- `yai-doctor`: local environment diagnostics.
-- `yai-purge`: local cleanup.
-- `yai-branch`: canonical branch-name generator.
-- `yai-pr-body`: PR body generator from templates.
-- `yai-pr-check`: strict PR body metadata validator.
-- `yai-dev-issue`: phase issue + MP closure creator (with legacy issue-body mode).
-- `yai-dev-milestone-body`: canonical PHASE milestone body generator.
-- `yai-dev-fix-phase`: dry-run/apply fixer for phase naming/labels/milestone alignment.
-- `yai-dev-label-sync`: dry-run/apply sync for label color palette (phase/track/class/type/area/work-type + core governance labels).
-- `yai-dev-branch`: alias of `yai-branch`.
-- `yai-dev-branch-sync`: create/check out the same branch across `yai`, `yai-cli`, `yai-mind`.
-- `yai-dev-pr-body`: alias of `yai-pr-body`.
-- `yai-dev-pr-check`: alias of `yai-pr-check`.
-- `yai-specs-sync`: sync `deps/yai-specs` pin and proof-pack refs (`manifest` + `README`).
-- `yai-docs-schema-check`: validate docs frontmatter schema.
-- `yai-docs-graph`: generate/check docs traceability graph + lock.
-- `yai-agent-pack`: generate/check canonical machine-readable agent pack.
-- `yai-docs-doctor`: run end-to-end docs-governance checks for CI/local.
-- `yai-architecture-check`: hard-fail architecture alignment checker (`--changed`, `--all`, `--write`).
-
-## Quick Start
-
-- `tools/bin/yai-dev-branch --type feat --issue 123 --area root --desc hardening-forward`
-- `tools/bin/yai-dev-pr-body --template default --issue 123 --mp-id MP-ROOT-HARDENING-0.1.0 --runbook docs/runbooks/root-hardening.md#phase-0-1-0-protocol-guardrails --out .pr/PR_BODY.md`
-- `tools/bin/yai-dev-pr-check .pr/PR_BODY.md`
-- `tools/bin/yai-dev-milestone-body --track contract-baseline-lock --phase 0.1.0 --rb-anchor docs/runbooks/contract-baseline-lock.md#0.1.0 --mp-id MP-CONTRACT-BASELINE-LOCK-0.1.0`
-- `tools/bin/yai-dev-issue phase --track contract-baseline-lock --phase 0.1.0 --rb-id RB-CONTRACT-BASELINE-LOCK --title \"Pin Baseline Freeze\" --rb-anchor docs/runbooks/contract-baseline-lock.md#0.1.0 --mp-id MP-CONTRACT-BASELINE-LOCK-0.1.0`
-- `tools/bin/yai-dev-issue mp-closure --track contract-baseline-lock --phase 0.1.0 --mp-id MP-CONTRACT-BASELINE-LOCK-0.1.0`
-- `tools/bin/yai-dev-fix-phase --track contract-baseline-lock --phase 0.1.0 --repo yai-labs/yai`
-- `tools/bin/yai-dev-label-sync --repo yai-labs/yai`
-
-- `tools/bin/yai-dev-branch-sync --type chore --issue N/A --reason bootstrap --area governance --desc proof-pack-lock`
-
-- `tools/bin/yai-specs-sync --target origin/main`
+During migration, local workflows in `yai` may still execute these paths directly.
+Functional changes must be authored in `yai-infra` first and then synchronized.

--- a/tools/python/yai_tools/README.md
+++ b/tools/python/yai_tools/README.md
@@ -1,0 +1,9 @@
+# yai_tools (Mirror)
+
+This package is mirrored in `yai` for CI/runtime compatibility during hardening.
+
+Canonical source is:
+- `yai-infra/tools/python/yai_tools/`
+
+Do not implement new governance features here directly.
+Author changes in `yai-infra` and sync into `yai` until full cutover.


### PR DESCRIPTION
## IDs
- Issue-ID: N/A
- Issue-Reason (required if N/A): Tooling ownership externalization tracked in yai-labs/yai-infra#35
- Closes-Issue: N/A
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: 83d105659299a819bd2f935d0860541ecc32b671

## Issue linkage
- Closes N/A

## Classification
- Classification: OPS
- Compatibility: B

## Objective
Declare yai tools/bin and yai_tools package as mirrors while canonical ownership moves to yai-infra

## Evidence
- Positive:
  - Baseline commit verified: yai + yai-cli -> 51f0ef3b5985d9fbd18c8f794d03206055bc7f0d
  - git status -sb exit code = 0 (to be confirmed in CI/local run)
- Negative:
  - No runtime/protocol behavior change expected.

## Commands run
```bash
git status -sb
```

## Checklist
- [x] Issue linkage valid (`N/A` + reason)
- [x] Evidence is concrete (positive: 2, negative: 1)
- [x] Commands are listed and runnable (1)

## Cross-repo tracking
- Refs yai-labs/yai-infra#35
