### PR TITLE
chore(ci): add template drift-check against yai-infra

### DIFF
--- a/.github/workflows/verify-github-templates.yml
+++ b/.github/workflows/verify-github-templates.yml
@@ -1,0 +1,16 @@
+name: verify-github-templates
+
+on:
+  pull_request:
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE*"
+      - ".github/workflows/verify-github-templates.yml"
+  workflow_dispatch:
+
+jobs:
+  verify-template-sync:
+    uses: yai-labs/yai-infra/.github/workflows/reusable-verify-github-templates.yml@7395f1ee1cd0a298241ee3f3c0a4ee9ad54c5ca4
+    with:
+      infra_repo: yai-labs/yai-infra
+      infra_ref: 7395f1ee1cd0a298241ee3f3c0a4ee9ad54c5ca4


### PR DESCRIPTION
Issue-ID: N/A
Issue-Reason: Cross-repo template hardening tracked in yai-labs/yai-infra#45.
MP-ID: N/A
Runbook: N/A
Base-Commit: 1a96601293d5f2b373e89af53b60f4c8e00b8fb7
Classification: CHORE
Compatibility: A

## Summary
Add a consumer-side workflow to verify local GitHub templates are aligned with canonical templates in yai-infra.

## Impacted areas
- .github/workflows/verify-github-templates.yml

## Evidence
- Positive:
  - New workflow calls yai-infra reusable verifier pinned to commit 7395f1ee1cd0a298241ee3f3c0a4ee9ad54c5ca4.
  - Drift on issue/PR templates will fail CI deterministically.
- Negative:
  - No runtime code changes.
  - No Python/tooling relocation in this PR.

## Commands run
```bash
git -C /home/mothx/COMPUTER_SCIENCE/DEV_CODE/YAI/yai status -sb
git -C /home/mothx/COMPUTER_SCIENCE/DEV_CODE/YAI/yai diff -- .github/workflows/verify-github-templates.yml
```

Closes yai-labs/yai-infra#45