### PR TITLE
docs(runbook): bind Wave1 specs foundation to claims and MPs (#142)

### DIFF
--- a/docs/_generated/traceability.graph.v1.json
+++ b/docs/_generated/traceability.graph.v1.json
@@ -516,6 +516,231 @@
       "to": "docs/runbooks/root-hardening.md"
     },
     {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/REGISTRY.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md",
+      "relation": "milestone_pack_to_doc",
+      "to": "deps/yai-specs/SPEC_MAP.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md",
+      "relation": "milestone_pack_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
+    },
+    {
+      "from": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md",
+      "relation": "milestone_pack_to_runbook",
+      "to": "docs/runbooks/specs-refactor-foundation.md"
+    },
+    {
       "from": "docs/milestone-packs/specs-refactor-foundation/README.md",
       "relation": "milestone_pack_to_doc",
       "to": "deps/yai-specs/SPEC_MAP.md"
@@ -629,6 +854,11 @@
       "from": "docs/runbooks/specs-refactor-foundation.md",
       "relation": "runbook_to_adr",
       "to": "docs/design/adr/ADR-011-contract-baseline-lock.md"
+    },
+    {
+      "from": "docs/runbooks/specs-refactor-foundation.md",
+      "relation": "runbook_to_adr",
+      "to": "docs/design/adr/ADR-012-audit-convergence-gates.md"
     },
     {
       "from": "docs/runbooks/workspaces-lifecycle.md",
@@ -805,6 +1035,51 @@
     {
       "id": "docs/milestone-packs/root-hardening/MP-ROOT-HARDENING-0.1.5.md",
       "path": "docs/milestone-packs/root-hardening/MP-ROOT-HARDENING-0.1.5.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md",
+      "type": "milestone_pack"
+    },
+    {
+      "id": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md",
+      "path": "docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md",
       "type": "milestone_pack"
     },
     {

--- a/docs/_generated/traceability.lock.v1.json
+++ b/docs/_generated/traceability.lock.v1.json
@@ -1,6 +1,6 @@
 {
-  "edge_count": 128,
-  "node_count": 46,
+  "edge_count": 174,
+  "node_count": 55,
   "orphan_count": 2,
   "version": 1,
   "violation_count": 0

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md
@@ -1,0 +1,53 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.0
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.0 — Canonical Tree & Domain Separation"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/bin/yai-docs-trace-check --all
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.0
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.0 — Canonical Tree & Domain Separation`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.0 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/bin/yai-docs-trace-check --all` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.0/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md
@@ -1,0 +1,53 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.1
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.1 — Pure Mapping (Move/Rename Only)"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/bin/yai-docs-trace-check --all
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.1
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.1 — Pure Mapping (Move/Rename Only)`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.1 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/bin/yai-docs-trace-check --all` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.1/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.2.md
@@ -1,0 +1,53 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.2
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.2 — Sanity Link & Pointer Health"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/bin/yai-docs-trace-check --all
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.2
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.2 — Sanity Link & Pointer Health`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.2 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/bin/yai-docs-trace-check --all` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.2/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.3.md
@@ -1,0 +1,56 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.3
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.3 — Consumer-Ready Wiring in yai"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-SPEC-FIRST-PINNED
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/release/check_pins.sh
+  - tools/bin/yai-proof-check
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.3
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.3 — Consumer-Ready Wiring in yai`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.3 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/release/check_pins.sh` -> `PASS`
+- `tools/bin/yai-proof-check` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.3/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.4.md
@@ -1,0 +1,56 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.4
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.4 — Consumer-Ready Wiring in yai-cli"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-SPEC-FIRST-PINNED
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/release/check_pins.sh
+  - tools/bin/yai-proof-check
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.4
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.4 — Consumer-Ready Wiring in yai-cli`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.4 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/release/check_pins.sh` -> `PASS`
+- `tools/bin/yai-proof-check` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.4/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.5.md
@@ -1,0 +1,56 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.5
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.5 — CI Hard Guardrails"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+  - C-SKIP-FAIL-MANDATORY
+evidence_commands_required:
+  - tools/bin/yai-docs-trace-check --all
+  - tools/bin/yai-proof-check
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.5
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.5 — CI Hard Guardrails`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.5 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/bin/yai-docs-trace-check --all` -> `PASS`
+- `tools/bin/yai-proof-check` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.5/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.6.md
@@ -1,0 +1,55 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.6
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.6 — Internal Toolchain & Policy"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/bin/yai-docs-trace-check --all
+  - tools/bin/yai-proof-check
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.6
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.6 — Internal Toolchain & Policy`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.6 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/bin/yai-docs-trace-check --all` -> `PASS`
+- `tools/bin/yai-proof-check` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.6/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.7.md
@@ -1,0 +1,56 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.7
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.7 — Formal Binding & Traceability Matrix"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-AUTHORITY-SURFACE-RUNTIME
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/bin/yai-proof-check
+  - tools/bin/yai-docs-trace-check --all
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.7
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.7 — Formal Binding & Traceability Matrix`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.7 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/bin/yai-proof-check` -> `PASS`
+- `tools/bin/yai-docs-trace-check --all` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.7/`

--- a/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md
+++ b/docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.8.md
@@ -1,0 +1,56 @@
+---
+id: MP-SPECS-REFACTOR-FOUNDATION-0.1.8
+status: draft
+runbook: docs/runbooks/specs-refactor-foundation.md
+phase: "0.1.8 — TLA Reboot & Model-Check CI"
+adrs:
+  - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
+spec_anchors:
+  - deps/yai-specs/SPEC_MAP.md
+  - deps/yai-specs/REGISTRY.md
+claims:
+  - C-AUTHORITY-SURFACE-RUNTIME
+  - C-EVIDENCE-PACK-REPRODUCIBLE
+evidence_commands_required:
+  - tools/bin/yai-proof-check
+  - tools/bin/yai-docs-trace-check --all
+issues:
+  - "142"
+  - "yai-specs#9"
+---
+
+# MP-SPECS-REFACTOR-FOUNDATION-0.1.8
+
+## Metadata
+- Runbook: `docs/runbooks/specs-refactor-foundation.md`
+- Phase: `0.1.8 — TLA Reboot & Model-Check CI`
+- Wave issue: `#142`
+- Specs branch issue: `yai-specs#9`
+- Status: `draft`
+
+## Links
+- Plan: `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- Matrix: `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- Claims registry: `docs/audits/claims/infra-grammar.v0.1.json`
+- ADR: `docs/design/adr/ADR-011-contract-baseline-lock.md`
+- ADR: `docs/design/adr/ADR-012-audit-convergence-gates.md`
+
+## Objective
+Close phase 0.1.8 with explicit claim/evidence bindings and reproducible gate outputs.
+
+## Mandatory command outcomes
+- `tools/bin/yai-proof-check` -> `PASS`
+- `tools/bin/yai-docs-trace-check --all` -> `PASS`
+
+Closure policy: mandatory `SKIP` is treated as `FAIL`.
+
+## Definition of Done
+- [ ] Phase claim IDs are covered by evidence.
+- [ ] Mandatory commands are recorded with exit codes and outputs.
+- [ ] Cross-repo references are traceable (yai <-> yai-specs <-> yai-cli).
+- [ ] MP links from runbook phase and matrix remain valid.
+
+## Execution Snapshot
+- Status: `PLANNED`
+- Evidence bundle: `docs/milestone-packs/specs-refactor-foundation/evidence/0.1.8/`

--- a/docs/milestone-packs/specs-refactor-foundation/README.md
+++ b/docs/milestone-packs/specs-refactor-foundation/README.md
@@ -16,6 +16,12 @@ issues:
 Runbook reference:
 - `docs/runbooks/specs-refactor-foundation.md`
 
+Wave binding:
+- `https://github.com/yai-labs/yai/issues/142`
+- `https://github.com/yai-labs/yai-specs/issues/9`
+- `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+- `docs/audits/claims/infra-grammar.v0.1.json`
+
 Planned sequence:
 - `docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.0.md`
 - `docs/milestone-packs/specs-refactor-foundation/MP-SPECS-REFACTOR-FOUNDATION-0.1.1.md`
@@ -30,3 +36,4 @@ Planned sequence:
 Notes:
 - Keep phases mapping-only where required; avoid normative content changes in structural phases.
 - Attach cross-repo pin/evidence outputs for `yai` and `yai-cli` consumers.
+- Closure semantics follow audit policy: mandatory `SKIP` is treated as `FAIL`.

--- a/docs/runbooks/specs-refactor-foundation.md
+++ b/docs/runbooks/specs-refactor-foundation.md
@@ -4,17 +4,20 @@ title: Specs Refactor Foundation
 status: draft
 owner: governance
 effective_date: 2026-02-19
-revision: 2
+revision: 3
 supersedes: []
 depends_on:
   - RB-CONTRACT-BASELINE-LOCK
 adr_refs:
   - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
 decisions:
   - docs/design/adr/ADR-011-contract-baseline-lock.md
+  - docs/design/adr/ADR-012-audit-convergence-gates.md
 related:
   adr:
     - docs/design/adr/ADR-011-contract-baseline-lock.md
+    - docs/design/adr/ADR-012-audit-convergence-gates.md
   specs:
     - deps/yai-specs/SPEC_MAP.md
     - deps/yai-specs/REGISTRY.md
@@ -86,6 +89,21 @@ A *closure artifact* for a phase: what changed, proof evidence, links to issues/
 - `yai` build + verify scripts
 - `yai-cli` build + tests/vectors
 
+### 3.1 Audit Convergence Binding (Wave 1)
+This runbook is Wave 1 under:
+- `docs/program-delivery/audit-convergence/EXECUTION-PLAN-v0.1.0.md`
+- `docs/program-delivery/audit-convergence/AUDIT-CONVERGENCE-MATRIX-v0.1.0.md`
+
+Claims source of truth:
+- `docs/audits/claims/infra-grammar.v0.1.json`
+
+Wave tracking:
+- `https://github.com/yai-labs/yai/issues/142`
+- `https://github.com/yai-labs/yai-specs/issues/9`
+
+Mandatory closure policy:
+- for mandatory evidence checks, `SKIP` is treated as `FAIL`.
+
 ---
 
 ## 4) Sequencing (global program position)
@@ -127,6 +145,9 @@ A phase is "closed" only when:
 ### 0.1.0 - Canonical Tree & Domain Separation
 **Claim:** repository layout is canonical, navigable, and domain-separated.  
 **Scope:** boundaries between `docs/`, `contracts/`, `specs/`, `formal/`, `compliance/`, `vectors/`, `tools/`.  
+**Claim IDs:** `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/bin/yai-docs-trace-check --all`
 **Work (typical):**
 - ensure each domain has a landing README,
 - ensure "source-of-truth pointers" exist (SPEC_MAP / REGISTRY),
@@ -150,6 +171,9 @@ A phase is "closed" only when:
 **Claim:** mapping cleanup is structural only (move/rename), no normative content changes.  
 **Scope:** move/rename, deduplicate wrong placements, normalize paths.  
 **Hard rule:** normative artifacts content must remain identical (byte-level if possible).
+**Claim IDs:** `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/bin/yai-docs-trace-check --all`
 
 **Work (typical):**
 - move files to correct domains,
@@ -173,6 +197,9 @@ A phase is "closed" only when:
 ### 0.1.2 - Sanity Link & Pointer Health
 **Claim:** no broken links or ghost paths; indexes are coherent.  
 **Scope:** markdown links, anchors, SPEC_MAP/REGISTRY references, pointer docs.  
+**Claim IDs:** `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/bin/yai-docs-trace-check --all`
 **Work (typical):**
 - fix broken relative links,
 - fix missing anchors,
@@ -195,6 +222,10 @@ A phase is "closed" only when:
 ### 0.1.3 - Consumer-Ready Wiring in `yai`
 **Claim:** `yai` consumes `yai-specs` deterministically under the new structure.  
 **Scope:** pins/tags/commit refs, include paths, build wiring, verify scripts.  
+**Claim IDs:** `C-SPEC-FIRST-PINNED`, `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/release/check_pins.sh`
+- `tools/bin/yai-proof-check`
 **Work (typical):**
 - update include paths to new canonical structure,
 - ensure `tools/release/check_pins.sh` (or equivalent) gates drift,
@@ -218,6 +249,10 @@ A phase is "closed" only when:
 ### 0.1.4 - Consumer-Ready Wiring in `yai-cli`
 **Claim:** `yai-cli` remains aligned and deterministic after specs mapping.  
 **Scope:** pin, includes, references, vectors usage, CLI build/tests.  
+**Claim IDs:** `C-SPEC-FIRST-PINNED`, `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/release/check_pins.sh`
+- `tools/bin/yai-proof-check`
 **Gate:**
 - `yai-cli` build/tests green,
 - pin check green,
@@ -236,6 +271,10 @@ A phase is "closed" only when:
 ### 0.1.5 - CI Hard Guardrails (Enterprise)
 **Claim:** PRs are **non-mergable** if any required check fails; logs are readable; checks are separated.  
 **Scope:** `yai-specs` CI and repo gates.
+**Claim IDs:** `C-EVIDENCE-PACK-REPRODUCIBLE`, `C-SKIP-FAIL-MANDATORY`  
+**Mandatory evidence commands:**
+- `tools/bin/yai-docs-trace-check --all`
+- `tools/bin/yai-proof-check`
 
 **Work (minimum deliverables):**
 - Docs lint: markdownlint + internal link-check
@@ -276,6 +315,10 @@ A phase is "closed" only when:
 ### 0.1.6 - Internal Toolchain & Policy (Enterprise)
 **Claim:** validate/format/policy/release operations are repeatable locally and in CI.  
 **Scope:** toolchain scripts and policy gates.
+**Claim IDs:** `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/bin/yai-docs-trace-check --all`
+- `tools/bin/yai-proof-check`
 
 **Work (minimum deliverables):**
 - `tools/validate/validate_all.sh` aggregator
@@ -315,6 +358,10 @@ A phase is "closed" only when:
 ### 0.1.7 - Formal Binding & Traceability Matrix (Enterprise)
 **Claim:** contracts <-> specs <-> vectors <-> formal mapping is machine-verifiable.  
 **Scope:** `formal/` bindings + traceability matrix + validators + CI gate.
+**Claim IDs:** `C-AUTHORITY-SURFACE-RUNTIME`, `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/bin/yai-proof-check`
+- `tools/bin/yai-docs-trace-check --all`
 
 **Work (minimum deliverables):**
 - Binding docs for each area:
@@ -353,6 +400,10 @@ A phase is "closed" only when:
 - **quick** always runs on PR and stays green,
 - **deep** runs on schedule/manual and is stabilized over time,
 - traceability maps to real properties/configs.
+**Claim IDs:** `C-AUTHORITY-SURFACE-RUNTIME`, `C-EVIDENCE-PACK-REPRODUCIBLE`  
+**Mandatory evidence commands:**
+- `tools/bin/yai-proof-check`
+- `tools/bin/yai-docs-trace-check --all`
 
 **Work (minimum deliverables):**
 - Standard runner:
@@ -382,6 +433,7 @@ A phase is "closed" only when:
 
 ## 7) Verification (commands)
 > Commands differ slightly per repo. The point is: **each phase has a deterministic gate**.
+> Mandatory check closure semantics: `SKIP = FAIL`.
 
 ### In `yai-specs` (foundation gates)
 ```bash


### PR DESCRIPTION
## IDs
- Issue-ID: #142
- Issue-Reason (required if N/A): N/A
- Closes-Issue: Closes #142
- MP-ID: MP-SPECS-REFACTOR-FOUNDATION-0.1.0
- Runbook: docs/runbooks/specs-refactor-foundation.md#phase-0-1-0-canonical-tree
- Base-Commit: c7a256d8664ac5f9fed83b6ece0f9445649adfc2

## Issue linkage
- Closes #142

## Classification
- Classification: DOCS
- Compatibility: A

## Objective
Re-center Wave1 specs-refactor runbook with claim IDs, mandatory evidence commands, and milestone-pack phase scaffolding aligned to the convergence matrix.

## Docs touched
- docs-only change (explicit file list not provided)

## Spec/Contract delta
- No spec/contract delta; docs/governance update only.

## Evidence
- Positive:
  - Baseline commit verified: yai + yai-cli -> 30d04d08fc6aba988b1fa20fb8e28cf886b8ccf7
  - bash tools/release/check_pins.sh exit code = 0
  - tools/bin/yai-docs-trace-check --all exit code = 0
  - tools/bin/yai-proof-check exit code = 0
- Negative:
  - No runtime/protocol behavior change expected.

## Commands run
```bash
bash tools/release/check_pins.sh
tools/bin/yai-docs-trace-check --all
tools/bin/yai-proof-check
```

## Checklist
- [x] Issue linkage valid (`#142`)
- [x] Evidence is concrete (positive: 4, negative: 1)
- [x] Commands are listed and runnable (3)
- [x] Docs touched is explicit (1)
- [x] Spec/contract delta is explicit (1)
- [x] Link/alignment validation command included
