### PR TITLE
chore(ci): pin project-status-sync reusable workflow to infra SHA

### DIFF
--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   sync:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-project-status-sync.yml@main
+    uses: yai-labs/yai-infra/.github/workflows/reusable-project-status-sync.yml@cb04d0d22cac40e14c7a9150a3c337b70993ecbc
     with:
       project_owner: yai-labs
       project_number: 5


### PR DESCRIPTION
## IDs
- Issue-ID: #166
- Issue-Reason (required if N/A): N/A
- Closes-Issue: Closes #166
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: 3672c3c440754bc7cec9f50f1833234999c17000

## Issue linkage
- Closes #166

## Classification
- Classification: OPS
- Compatibility: B

## Objective
Pin yai project-status-sync reusable workflow to immutable yai-infra SHA

## Docs touched
- .github/workflows/project-status-sync.yml

## Spec/Contract delta
- No runtime/spec contract change

## Evidence
- Positive:
  - Removed @main reference and pinned to yai-infra commit cb04d0d...
- Negative:
  - No code/runtime behavior modified

## Commands run
```bash
rg -n "reusable-project-status-sync.yml@" .github/workflows/project-status-sync.yml
```

## Checklist
- [x] Issue linkage valid (`#166`)
- [x] Evidence is concrete (positive: 1, negative: 1)
- [x] Commands are listed and runnable (1)
- [x] Docs touched is explicit (1)
- [x] Spec/contract delta is explicit (1)
- [ ] Link/alignment validation command included
