### PR TITLE
chore(tooling): make python wrappers infra-first with local fallback

### DIFF
--- a/tools/bin/yai-agent-pack
+++ b/tools/bin/yai-agent-pack
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export PYTHONPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../python" && pwd)${PYTHONPATH:+:$PYTHONPATH}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-agent-pack"
+
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli agent-pack "$@"

--- a/tools/bin/yai-architecture-check
+++ b/tools/bin/yai-architecture-check
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export PYTHONPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../python" && pwd)${PYTHONPATH:+:$PYTHONPATH}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-architecture-check"
+
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli architecture-check "$@"

--- a/tools/bin/yai-branch
+++ b/tools/bin/yai-branch
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-export PYTHONPATH="$ROOT/tools/python"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-branch"
 
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli branch "$@"

--- a/tools/bin/yai-changelog-check
+++ b/tools/bin/yai-changelog-check
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-PYTHON="${PYTHON:-python3}"
-export PYTHONPATH="${ROOT}/tools/python"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-changelog-check"
 
-exec "${PYTHON}" -m yai_tools.verify.changelog "$@"
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+PYTHON="${PYTHON:-python3}"
+export PYTHONPATH="$ROOT/tools/python"
+exec "$PYTHON" -m yai_tools.verify.changelog "$@"

--- a/tools/bin/yai-dev-fix-phase
+++ b/tools/bin/yai-dev-fix-phase
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-export PYTHONPATH="$ROOT/tools/python"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-dev-fix-phase"
 
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli fix-phase "$@"

--- a/tools/bin/yai-dev-issue
+++ b/tools/bin/yai-dev-issue
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-export PYTHONPATH="$ROOT/tools/python"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-dev-issue"
 
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli dev-issue "$@"

--- a/tools/bin/yai-dev-label-sync
+++ b/tools/bin/yai-dev-label-sync
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-export PYTHONPATH="$ROOT/tools/python"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-dev-label-sync"
 
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli label-sync "$@"

--- a/tools/bin/yai-dev-milestone-body
+++ b/tools/bin/yai-dev-milestone-body
@@ -2,6 +2,13 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-export PYTHONPATH="$ROOT/tools/python"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-dev-milestone-body"
 
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli milestone-body "$@"

--- a/tools/bin/yai-docs-graph
+++ b/tools/bin/yai-docs-graph
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export PYTHONPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../python" && pwd)${PYTHONPATH:+:$PYTHONPATH}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-docs-graph"
+
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli docs-graph "$@"

--- a/tools/bin/yai-docs-schema-check
+++ b/tools/bin/yai-docs-schema-check
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export PYTHONPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../python" && pwd)${PYTHONPATH:+:$PYTHONPATH}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_ROOT_DEFAULT="$(cd "$ROOT/.." && pwd)/yai-infra"
+INFRA_ROOT="${YAI_INFRA_ROOT:-$INFRA_ROOT_DEFAULT}"
+INFRA_SCRIPT="$INFRA_ROOT/tools/bin/yai-docs-schema-check"
+
+if [[ -z "${YAI_INFRA_DELEGATED:-}" && -x "$INFRA_SCRIPT" ]]; then
+  exec env YAI_INFRA_DELEGATED=1 "$INFRA_SCRIPT" "$@"
+fi
+
+export PYTHONPATH="$ROOT/tools/python"
 exec python3 -m yai_tools.cli docs-schema-check "$@"


### PR DESCRIPTION
## IDs
- Issue-ID: #168
- Issue-Reason (required if N/A): N/A
- Closes-Issue: Closes #168
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: dd9c849e8917f862f8207519f8c7efe43005ebfb

## Issue linkage
- Closes #168

## Classification
- Classification: OPS
- Compatibility: B

## Objective
Switch remaining python governance wrappers in yai/tools/bin to infra-first delegation with local fallback

## Docs touched
- tools/bin/yai-agent-pack
- tools/bin/yai-architecture-check
- tools/bin/yai-branch
- tools/bin/yai-changelog-check
- tools/bin/yai-dev-fix-phase
- tools/bin/yai-dev-issue
- tools/bin/yai-dev-label-sync
- tools/bin/yai-dev-milestone-body
- tools/bin/yai-docs-graph
- tools/bin/yai-docs-schema-check

## Spec/Contract delta
- No runtime/spec contract change

## Evidence
- Positive:
  - All listed wrappers now delegate to yai-infra tools/bin when available
  - Fallback local execution path preserved to avoid cutover regressions
- Negative:
  - No runtime C/core paths changed

## Commands run
```bash
bash -n tools/bin/yai-agent-pack tools/bin/yai-architecture-check tools/bin/yai-branch tools/bin/yai-changelog-check tools/bin/yai-dev-fix-phase tools/bin/yai-dev-issue tools/bin/yai-dev-label-sync tools/bin/yai-dev-milestone-body tools/bin/yai-docs-graph tools/bin/yai-docs-schema-check
```

## Checklist
- [x] Issue linkage valid (`#168`)
- [x] Evidence is concrete (positive: 2, negative: 1)
- [x] Commands are listed and runnable (1)
- [x] Docs touched is explicit (10)
- [x] Spec/contract delta is explicit (1)
- [x] Link/alignment validation command included
