### PR TITLE
ci(governance): consume yai-infra reusable workflows (wrappers only)

### DIFF
--- a/.github/.managed-by-yai-infra
+++ b/.github/.managed-by-yai-infra
@@ -1,0 +1,3 @@
+managed_by: yai-infra
+template_source: governance/templates/github/.github
+drift_policy: hard-fail

--- a/.github/workflows/auto-label-issue.yml
+++ b/.github/workflows/auto-label-issue.yml
@@ -10,8 +10,11 @@ permissions:
 
 jobs:
   label:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-auto-label-issue.yml@v0.1.1-rc2
+    uses: yai-labs/yai-infra/.github/workflows/reusable-auto-label-issue.yml@main
     with:
+      org: yai-labs
+      project_number: 2
       default_track_label: track:audit-convergence
       default_track_color: 1d76db
       default_track_description: Audit convergence track
+    secrets: inherit

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -10,10 +10,11 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Apply labels from .github/labeler.yml
-        uses: actions/labeler@v5
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          sync-labels: true
+    uses: yai-labs/yai-infra/.github/workflows/reusable-auto-label-pr.yml@main
+    with:
+      org: yai-labs
+      project_number: 2
+      default_track_label: track:audit-convergence
+      default_track_color: 1d76db
+      default_track_description: Audit convergence track
+    secrets: inherit

--- a/.github/workflows/issue-project-status-sync.yml
+++ b/.github/workflows/issue-project-status-sync.yml
@@ -11,9 +11,8 @@ permissions:
 
 jobs:
   sync-issue-item:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-issue-project-status-sync.yml@v0.1.1-rc2
+    uses: yai-labs/yai-infra/.github/workflows/reusable-issue-project-status-sync.yml@main
     with:
-      project_owner: yai-labs
+      org: yai-labs
       project_number: 2
-    secrets:
-      project_token: ${{ secrets.YAI_PROJECT_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/pr-issue-enforcement.yml
+++ b/.github/workflows/pr-issue-enforcement.yml
@@ -10,64 +10,8 @@ permissions:
 
 jobs:
   enforce:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Enforce issue linkage policy
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            const body = pr.body || "";
-            const { data: fullPr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-            });
-            const labels = (fullPr.labels || []).map((l) => l.name || "");
-
-            const classificationMatch = body.match(/Classification:\s*([A-Z]+)/i);
-            const classification = classificationMatch ? classificationMatch[1].toUpperCase() : "";
-
-            const hasDocsLabel = labels.includes("type:docs") || labels.includes("work-type:docs");
-            const hasCiLabel = labels.includes("type:ci") || labels.includes("work-type:ci");
-            const docsExempt = hasDocsLabel && classification === "DOCS";
-            const ciExempt = hasCiLabel;
-
-            if (docsExempt || ciExempt) {
-              core.info(
-                `Issue-link enforcement skipped due to exemption: docsExempt=${docsExempt}, ciExempt=${ciExempt}`
-              );
-              return;
-            }
-
-            const hasClosingRef = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+\b/i.test(body);
-            const closingRefMatch = body.match(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/i);
-            const closingIssueNum = closingRefMatch ? closingRefMatch[1] : "";
-
-            const issueIdMatch = body.match(/Issue-ID:\s*#?(\d+)/i);
-            const hasIssueId = !!issueIdMatch;
-            const issueIdNum = hasIssueId ? issueIdMatch[1] : "";
-
-            const issueReasonMatch = body.match(/Issue-Reason[^:\n\r]*:\s*([^\n\r]+)/i);
-            const issueReason = issueReasonMatch ? issueReasonMatch[1].trim() : "";
-            const hasIssueReason =
-              issueReason.length > 0 &&
-              !/^<.*>$/.test(issueReason) &&
-              !/^N\/A$/i.test(issueReason) &&
-              !/^(todo|tbd)$/i.test(issueReason);
-
-            if (hasClosingRef || hasIssueReason) {
-              if (hasIssueId && closingIssueNum && issueIdNum !== closingIssueNum) {
-                core.warning(
-                  `Issue-ID (#${issueIdNum}) and closing reference (#${closingIssueNum}) differ.`
-                );
-              }
-              core.info(
-                `Issue-link policy satisfied: hasClosingRef=${hasClosingRef}, hasIssueReason=${hasIssueReason}`
-              );
-              return;
-            }
-
-            core.setFailed(
-              "PR must include either an auto-closing reference (e.g. `Closes #123`) or a non-empty `Issue-Reason:`."
-            );
+    uses: yai-labs/yai-infra/.github/workflows/reusable-pr-issue-enforcement.yml@main
+    with:
+      org: yai-labs
+      project_number: 2
+    secrets: inherit

--- a/.github/workflows/pr-milestone-sync.yml
+++ b/.github/workflows/pr-milestone-sync.yml
@@ -11,54 +11,8 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Sync PR milestone from linked issue
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const pr = context.payload.pull_request;
-            const body = pr.body || "";
-
-            const issueRefs = new Set();
-            const closeRe = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:#(\d+)|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+))/gi;
-            let m;
-            while ((m = closeRe.exec(body)) !== null) {
-              const n = m[1] || m[2];
-              if (n) issueRefs.add(Number(n));
-            }
-
-            if (issueRefs.size === 0) {
-              core.info("No closing issue reference found in PR body; skipping milestone sync.");
-              return;
-            }
-
-            const issueNumber = [...issueRefs][0];
-            core.info(`Using linked issue #${issueNumber} for milestone sync`);
-
-            const { data: issue } = await github.rest.issues.get({
-              owner,
-              repo,
-              issue_number: issueNumber,
-            });
-
-            if (!issue.milestone) {
-              core.info(`Issue #${issueNumber} has no milestone; skipping milestone sync.`);
-              return;
-            }
-
-            const targetMilestone = issue.milestone.number;
-            const currentMilestone = pr.milestone ? pr.milestone.number : null;
-            if (currentMilestone === targetMilestone) {
-              core.info(`PR milestone already aligned to '${issue.milestone.title}'.`);
-            } else {
-              await github.rest.issues.update({
-                owner,
-                repo,
-                issue_number: pr.number,
-                milestone: targetMilestone,
-              });
-              core.info(`PR milestone set to '${issue.milestone.title}' from issue #${issueNumber}.`);
-            }
+    uses: yai-labs/yai-infra/.github/workflows/reusable-pr-milestone-sync.yml@main
+    with:
+      org: yai-labs
+      project_number: 2
+    secrets: inherit

--- a/.github/workflows/project-backfill-sync.yml
+++ b/.github/workflows/project-backfill-sync.yml
@@ -13,13 +13,12 @@ permissions:
 
 jobs:
   backfill:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-project-backfill-sync.yml@v0.1.1-rc2
+    uses: yai-labs/yai-infra/.github/workflows/reusable-project-backfill-sync.yml@main
     with:
-      project_owner: yai-labs
+      org: yai-labs
       project_number: 2
       default_phase: "0.1.0"
       default_track: audit-convergence
       default_assignee: francescomaiomascio
       allowed_tracks: contract-baseline-lock,specs-refactor-foundation,audit-convergence
-    secrets:
-      project_token: ${{ secrets.YAI_PROJECT_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/project-intake-sync.yml
+++ b/.github/workflows/project-intake-sync.yml
@@ -14,13 +14,12 @@ permissions:
 
 jobs:
   intake:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-project-intake-sync.yml@v0.1.1-rc2
+    uses: yai-labs/yai-infra/.github/workflows/reusable-project-intake-sync.yml@main
     with:
-      project_owner: yai-labs
+      org: yai-labs
       project_number: 2
       default_assignee: francescomaiomascio
       default_phase: "0.1.0"
       default_track: audit-convergence
       allowed_tracks: contract-baseline-lock,specs-refactor-foundation,audit-convergence
-    secrets:
-      project_token: ${{ secrets.YAI_PROJECT_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/project-status-sync.yml
+++ b/.github/workflows/project-status-sync.yml
@@ -6,9 +6,8 @@ on:
 
 jobs:
   sync:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-project-status-sync.yml@v0.1.1-rc2
+    uses: yai-labs/yai-infra/.github/workflows/reusable-project-status-sync.yml@main
     with:
-      project_owner: yai-labs
+      org: yai-labs
       project_number: 2
-    secrets:
-      project_token: ${{ secrets.YAI_PROJECT_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -45,7 +45,10 @@ jobs:
 
   call-validate-changelog:
     needs: prepare-shas
-    uses: yai-labs/yai-infra/.github/workflows/reusable-validate-changelog.yml@717ad404eb98e889b72201bd0bc65e3710441449
+    uses: yai-labs/yai-infra/.github/workflows/reusable-validate-changelog.yml@main
     with:
+      org: yai-labs
+      project_number: 2
       base_sha: ${{ needs.prepare-shas.outputs.base_sha }}
       head_sha: ${{ needs.prepare-shas.outputs.head_sha }}
+    secrets: inherit

--- a/.github/workflows/validate-pr-metadata.yml
+++ b/.github/workflows/validate-pr-metadata.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   call-validate-pr-metadata:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-validate-pr-metadata.yml@717ad404eb98e889b72201bd0bc65e3710441449
+    uses: yai-labs/yai-infra/.github/workflows/reusable-validate-pr-metadata.yml@main
     with:
+      org: yai-labs
+      project_number: 2
       pr_body: ${{ github.event.pull_request.body || '' }}
+    secrets: inherit

--- a/.github/workflows/verify-github-templates.yml
+++ b/.github/workflows/verify-github-templates.yml
@@ -5,12 +5,16 @@ on:
     paths:
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/PULL_REQUEST_TEMPLATE*"
+      - ".github/.managed-by-yai-infra"
       - ".github/workflows/verify-github-templates.yml"
   workflow_dispatch:
 
 jobs:
   verify-template-sync:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-verify-github-templates.yml@7395f1ee1cd0a298241ee3f3c0a4ee9ad54c5ca4
+    uses: yai-labs/yai-infra/.github/workflows/reusable-verify-github-templates.yml@main
     with:
+      org: yai-labs
+      project_number: 2
       infra_repo: yai-labs/yai-infra
-      infra_ref: 7395f1ee1cd0a298241ee3f3c0a4ee9ad54c5ca4
+      infra_ref: main
+    secrets: inherit

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   call-verify:
-    uses: yai-labs/yai-infra/.github/workflows/reusable-verify.yml@v0.1.0-rc1
+    uses: yai-labs/yai-infra/.github/workflows/reusable-verify.yml@main
     with:
+      org: yai-labs
+      project_number: 2
       python: false
+    secrets: inherit


### PR DESCRIPTION
Closes #173

## Scope
- Replace local governance logic with thin wrappers to yai-infra reusable workflows.
- Keep product runtime workflows local (`ci.yml`, `bundle.yml`, `pages-doxygen.yml`).
- Add `.github/.managed-by-yai-infra`.
- Standardize wrapper inputs to `org` + `project_number` and use `secrets: inherit`.

## Verification
- YAML parse for all workflow files.
- Canonical template mirror diff vs yai-infra is clean (including marker).
