### PR TITLE
docs: daily dashboard/worklog + governance/tooling pointers to infra

### DIFF
--- a/docs/00-dashboard.md
+++ b/docs/00-dashboard.md
@@ -1,0 +1,18 @@
+# YAI Daily Dashboard
+
+## Current Focus
+
+- Active program track: `docs/20-program/audit-convergence/`
+- Active qualification targets: `docs/40-qualification/`
+- Active catalog scenarios: `docs/30-catalog/scenarios/`
+
+## Today Checklist
+
+- Confirm active PR and linked issue are in the correct project board.
+- Run required verification commands for the touched area.
+- Update `docs/90-worklog/` with outcome + evidence links.
+
+## Next Actions
+
+- Continue runbook phases under `docs/20-program/23-runbooks/`.
+- Keep governance automation contract synced from `yai-infra`.

--- a/docs/60-guides/README.md
+++ b/docs/60-guides/README.md
@@ -3,9 +3,15 @@
 Human-facing usage and contributor guidance.
 
 Indexes:
+
 - Getting started: `docs/60-guides/getting-started/README.md`
 - Dev guide: `docs/60-guides/dev-guide/README.md`
 - User guide: `docs/60-guides/user-guide/README.md`
 - Mind build guide: `docs/60-guides/dev-guide/mind-build.md`
 - Mind testing guide: `docs/60-guides/dev-guide/mind-testing.md`
 - Mind workflow guide: `docs/60-guides/dev-guide/mind-workflow.md`
+
+Governance tooling/process standards are consumed from `yai-infra`:
+
+- `https://github.com/yai-labs/yai-infra/tree/main/docs/standards`
+- `https://github.com/yai-labs/yai-infra/tree/main/docs/tooling`

--- a/docs/60-guides/dev-guide/README.md
+++ b/docs/60-guides/dev-guide/README.md
@@ -1,24 +1,31 @@
 # Dev Guide
 
-Developer-facing operational guidance for docs, governance, and delivery execution.
+Developer-facing guidance for product runtime work in `yai`.
 
-Core guides:
+## Core local guides
+
 - `repo-workflow.md`
-- `cross-repo-workflow.md`
 - `build.md`
 - `testing.md`
 - `debugging.md`
 - `release.md`
+- `mind-build.md`
+- `mind-testing.md`
+- `mind-workflow.md`
 
-Governance and templates:
-- `agent-contract.md`
-- `agent-playbook.md`
+## Governance/process pointers (canonical in yai-infra)
+
+- `cross-repo-workflow.md`
 - `github-templates.md`
 - `github-issue-templates.md`
 - `github-milestone-template.md`
 - `github-program-governance.md`
-
-Checks and standards:
-- `checklists/*.md`
+- `repo-tooling.md`
 - `toolchain-contract-v1.md`
+
+## Still local
+
+- `agent-contract.md`
+- `agent-playbook.md`
 - `tooling-layout.md`
+- `checklists/*.md`

--- a/docs/60-guides/dev-guide/cross-repo-workflow.md
+++ b/docs/60-guides/dev-guide/cross-repo-workflow.md
@@ -1,9 +1,12 @@
 # Cross-Repo Workflow
 
-YAI governance spans multiple repos (`yai`, `yai-specs`, `yai-cli`, `yai-mind`).
+Cross-repo governance automation standards are defined in `yai-infra`.
 
-Rules:
-- Keep normative spec changes in `yai-specs` branches.
-- Keep runtime enforcement and program docs in `yai` branches.
-- Link related PRs/issues with explicit dependency notes.
-- Update pins only after source branches are merged.
+See:
+
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/standards/project-automation-policy.md`
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/tooling/governance-suite.md`
+
+For YAI product execution specifics, use local runbooks under:
+
+- `docs/20-program/23-runbooks/`

--- a/docs/60-guides/dev-guide/github-issue-templates.md
+++ b/docs/60-guides/dev-guide/github-issue-templates.md
@@ -1,9 +1,8 @@
 # GitHub Issue Templates
 
-Use dedicated templates for:
-- runbook phases,
-- milestone closure,
-- docs governance changes,
-- bugs/features.
+Issue template contract is managed in `yai-infra`.
 
-Keep field names stable when possible to preserve automation compatibility.
+See:
+
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/standards/github-templates.md`
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/tooling/governance-suite.md`

--- a/docs/60-guides/dev-guide/github-milestone-template.md
+++ b/docs/60-guides/dev-guide/github-milestone-template.md
@@ -1,10 +1,5 @@
 # GitHub Milestone Template
 
-Milestone naming pattern:
-- `<track>-<version>` (example: `root-hardening-0.1.x`)
+Milestone governance policy is managed in `yai-infra`:
 
-Each milestone should include:
-- scoped objective,
-- closure criteria,
-- linked runbook phases,
-- linked MP artifacts.
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/standards/project-automation-policy.md`

--- a/docs/60-guides/dev-guide/github-program-governance.md
+++ b/docs/60-guides/dev-guide/github-program-governance.md
@@ -1,8 +1,6 @@
 # GitHub Program Governance
 
-Program board usage baseline:
-- every issue tied to a runbook phase or MP closure,
-- required metadata fields filled,
-- status transitions reflected in docs artifacts.
+Program board automation contract is maintained in `yai-infra`:
 
-Do not close governance issues without evidence-linked closure notes.
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/standards/project-automation-policy.md`
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/tooling/governance-suite.md`

--- a/docs/60-guides/dev-guide/github-templates.md
+++ b/docs/60-guides/dev-guide/github-templates.md
@@ -1,7 +1,8 @@
 # GitHub Templates
 
-Template locations:
-- PR templates: `.github/PULL_REQUEST_TEMPLATE/`
-- Issue templates: `.github/ISSUE_TEMPLATE/`
+Canonical template policy is maintained in `yai-infra`:
 
-Template changes are governance changes and must be traceable in runbook/MP context.
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/standards/github-templates.md`
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/standards/github-template-residency.md`
+
+`yai` consumes mirrored templates and must not introduce local drift.

--- a/docs/60-guides/dev-guide/repo-tooling.md
+++ b/docs/60-guides/dev-guide/repo-tooling.md
@@ -1,10 +1,10 @@
 # Repo Tooling
 
-Operational tooling relevant to docs/governance:
-- `tools/bin/yai-docs-trace-check`
-- `../yai-infra/tools/bin/yai-docs-schema-check`
-- `../yai-infra/tools/bin/yai-docs-doctor`
-- `tools/bin/yai-proof-check`
-- `tools/bin/yai-verify`
+Governance tooling source-of-truth is `yai-infra`.
 
-Use `--check` mode in validation steps and attach outputs in evidence bundles.
+See:
+
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/tooling/github-actions-suite.md`
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/tooling/governance-suite.md`
+
+`yai/tools/bin` keeps thin wrappers only.

--- a/docs/60-guides/dev-guide/toolchain-contract-v1.md
+++ b/docs/60-guides/dev-guide/toolchain-contract-v1.md
@@ -1,8 +1,8 @@
 # Toolchain Contract v1
 
-The docs/governance toolchain must provide:
-- deterministic traceability checks,
-- schema validation for frontmatter/contracts,
-- reproducible generated artifacts.
+Canonical governance/toolchain contracts are published in `yai-infra`:
 
-A change that breaks this contract requires explicit ADR/runbook acknowledgement.
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/tooling/github-actions-suite.md`
+- `https://github.com/yai-labs/yai-infra/blob/main/docs/standards/docs-residency.md`
+
+`yai` must consume, not fork, governance tooling contracts.

--- a/docs/90-worklog/README.md
+++ b/docs/90-worklog/README.md
@@ -1,0 +1,14 @@
+# Worklog
+
+Use this folder for chronological execution notes tied to issues/PRs.
+
+## File naming
+
+- `YYYY-MM-DD.md` for daily logs.
+
+## Required sections
+
+- Scope worked
+- Commands executed
+- Evidence links (PR/issue/log)
+- Decisions / follow-ups

--- a/docs/90-worklog/TEMPLATE.md
+++ b/docs/90-worklog/TEMPLATE.md
@@ -1,0 +1,23 @@
+# YYYY-MM-DD Worklog
+
+## Scope
+
+- 
+
+## Commands
+
+- 
+
+## Evidence
+
+- Issue:
+- PR:
+- CI run:
+
+## Decisions
+
+- 
+
+## Follow-ups
+
+- 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,30 +1,31 @@
 # Documentation Map (Docs IA v1)
 
-This repository now uses a hard-cut layered documentation structure.
-Legacy internal path aliases are removed.
+This repository uses a hard-cut layered documentation structure.
 
-## Start Here (Layered Hubs)
+## Start Here
 
+- Daily dashboard: `docs/00-dashboard.md`
 - Platform: `docs/10-platform/`
 - Program: `docs/20-program/`
 - Catalog: `docs/30-catalog/`
 - Qualification: `docs/40-qualification/`
 - Validation: `docs/50-validation/`
 - Guides: `docs/60-guides/`
+- Worklog: `docs/90-worklog/`
 
 ## Canonical Anchors
 
 - Architecture: `docs/10-platform/architecture/`
-- Governance spine: `docs/20-program/spine.md`
-- Governance traceability: `docs/20-program/traceability.md`
+- Program spine: `docs/20-program/spine.md`
+- Program traceability: `docs/20-program/traceability.md`
 - Runbooks: `docs/20-program/23-runbooks/`
 - Milestone packs: `docs/20-program/24-milestone-packs/`
 - Program convergence: `docs/20-program/audit-convergence/`
 - Claims registry: `docs/50-validation/audits/claims/infra-grammar.v0.1.json`
 
-## Usage Model
+## Governance Tooling Source
 
-- Catalog (`30-catalog`) defines target capabilities and scenario specs.
-- Runbooks (`20-program/23-runbooks`) define implementation work.
-- Qualification (`40-qualification`) defines executable gates and evidence runs.
-- Validation (`50-validation`) carries audits and proof-verification outputs.
+Process/tooling/template governance standards are canonical in `yai-infra`:
+
+- `https://github.com/yai-labs/yai-infra/tree/main/docs/standards`
+- `https://github.com/yai-labs/yai-infra/tree/main/docs/tooling`


### PR DESCRIPTION
## IDs
- Issue-ID: #177
- Issue-Reason (required if N/A): N/A
- Closes-Issue: Closes #177
- MP-ID: N/A
- Runbook: N/A
- Base-Commit: d0eba14d66861e7a5240c27402d754eb04137a7b

## Issue linkage
- Closes #177

## Classification
- Classification: DOCS
- Compatibility: A

## Objective
Add a daily docs execution hub (`00-dashboard` + `90-worklog`) and remove duplicated governance/process guidance from `yai` by pointing to canonical `yai-infra` standards/tooling docs.

## Docs touched
- docs/00-dashboard.md
- docs/90-worklog/README.md
- docs/90-worklog/TEMPLATE.md
- docs/README.md
- docs/60-guides/README.md
- docs/60-guides/dev-guide/README.md
- docs/60-guides/dev-guide/cross-repo-workflow.md
- docs/60-guides/dev-guide/github-templates.md
- docs/60-guides/dev-guide/github-issue-templates.md
- docs/60-guides/dev-guide/github-milestone-template.md
- docs/60-guides/dev-guide/github-program-governance.md
- docs/60-guides/dev-guide/repo-tooling.md
- docs/60-guides/dev-guide/toolchain-contract-v1.md

## Spec/Contract delta
- No runtime/spec contract changes.
- Documentation authority for governance/tooling references moved to `yai-infra` pointers.

## Evidence
- Positive:
  - `tools/bin/yai-docs-trace-check --all` returned OK.
- Negative:
  - No runtime/build behavior touched.

## Commands run
```bash
tools/bin/yai-docs-trace-check --all
git status -sb
```

## Checklist
- [x] No broken links
- [x] Templates updated consistently (if touched)
- [x] Doc aligns with current repo state (no "future tense" lying)
