### PR TITLE
docs(sc102): add Wave 1 aggregate gate for D1 + D8

### DIFF
--- a/docs/30-catalog/scenarios/SC-102.md
+++ b/docs/30-catalog/scenarios/SC-102.md
@@ -4,7 +4,7 @@ title: Core Qualification - Contain -> Evidence (No Mind) - Cross-Domain
 status: draft
 owner: runtime
 effective_date: 2026-02-23
-revision: 2
+revision: 3
 tags:
   - catalog
   - scenario
@@ -133,7 +133,16 @@ FAIL se:
 - evidence/decision ambigue o mancanti
 - check required in SKIP
 
-## 10) Links
+## 10) Coverage status (Wave 1)
+
+Implemented and evidenced:
+- D1-digital/egress-v1 via `docs/40-qualification/QT-0.1-001-SC102/` and RT trials `RT-0.1-001..003`
+- D8-scientific/reproducibility-parameter-lock-v1 via `docs/40-qualification/RT-0.1-001-D8-PARAMS-LOCK/`
+
+Wave 1 aggregate gate:
+- `docs/40-qualification/QT-0.1-003-SC102-WAVE1/`
+
+## 11) Links
 - Domain reference: `docs/30-catalog/domains/D-MAJOR.md`
 - Qualification Gate: `QT-0.1-001-SC102` (`docs/40-qualification/QT-0.1-001-SC102/`)
 - Gates list: `docs/30-catalog/gates/QUALIFICATION-GATES-v0.1.0.md`

--- a/docs/40-qualification/QT-0.1-003-SC102-WAVE1/README.md
+++ b/docs/40-qualification/QT-0.1-003-SC102-WAVE1/README.md
@@ -1,0 +1,35 @@
+---
+id: QT-0.1-003-SC102-WAVE1
+title: SC-102 Wave 1 Aggregate Gate (D1 + D8)
+status: draft
+owner: runtime
+effective_date: 2026-02-25
+revision: 1
+catalog_scenario_ref: docs/30-catalog/scenarios/SC-102.md
+---
+
+# QT-0.1-003-SC102-WAVE1
+
+Aggregate qualification gate for SC-102 Wave 1.
+
+Scope:
+- D1 digital egress containment (`QT-0.1-001-SC102`, live mode)
+- D8 scientific params-lock containment (`RT-0.1-001-D8-PARAMS-LOCK`, docker profile)
+
+## Run
+
+```bash
+cd docs/40-qualification/QT-0.1-003-SC102-WAVE1
+./run/run-wave1.sh
+```
+
+## Expected outcome
+
+- D1 live: `3/3` pass
+- D8 docker deny: `3/3` pass
+- Both stages print explicit PASS markers.
+
+## Notes
+
+- This gate is an orchestration wrapper. Evidence remains in the child gate/trial folders.
+- It is intentionally strict: any stage failure exits non-zero.

--- a/docs/40-qualification/QT-0.1-003-SC102-WAVE1/run/run-wave1.sh
+++ b/docs/40-qualification/QT-0.1-003-SC102-WAVE1/run/run-wave1.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+QUAL_ROOT="$(cd "$DIR/../.." && pwd)"
+
+echo "[WAVE1] Stage 1/2: D1 live containment"
+(
+  cd "$QUAL_ROOT/QT-0.1-001-SC102"
+  QT_MODE=live DOMAIN_PACK_ID=D1-digital/egress-v1 BASELINE_ID=baseline-deny ./run/run-three.sh
+)
+
+echo "[WAVE1] Stage 2/2: D8 docker params-lock deny"
+(
+  cd "$QUAL_ROOT/RT-0.1-001-D8-PARAMS-LOCK"
+  BASELINE_ID=baseline-deny TARGET_PROFILE=docker ./run/run-three.sh
+)
+
+echo "[WAVE1] PASS: SC-102 Wave 1 (D1 + D8)"

--- a/docs/40-qualification/README.md
+++ b/docs/40-qualification/README.md
@@ -8,6 +8,7 @@ Purpose:
 Gate directories:
 - `docs/40-qualification/QT-0.1-001-SC102/`
 - `docs/40-qualification/QT-0.1-002-SC103/`
+- `docs/40-qualification/QT-0.1-003-SC102-WAVE1/`
 - `docs/40-qualification/RT-0.1-001-D1-EGRESS-CURL/`
 - `docs/40-qualification/RT-0.1-002-D1-EGRESS-OTEL/`
 - `docs/40-qualification/RT-0.1-003-D1-EGRESS-S3/`


### PR DESCRIPTION
Issue-ID: N/A
Issue-Reason: Establish SC-102 Wave 1 aggregate execution path before next D-major rollout.
MP-ID: N/A
Runbook: N/A
Base-Commit: 69d16d46cfea12e1634ed925b2401e42ab1ae34e
Classification: DOCS
Compatibility: non-breaking

## Context
SC-102 has D1 and D8 qualification assets, but no single canonical gate to execute Wave 1 coverage in one command.

## Changes
- add `docs/40-qualification/QT-0.1-003-SC102-WAVE1/` with aggregate runner `run/run-wave1.sh`
- update `docs/30-catalog/scenarios/SC-102.md` with explicit Wave 1 coverage status (D1 + D8)
- update `docs/40-qualification/README.md` index with the new gate

## Evidence
- Positive:
  - `bash -n docs/40-qualification/QT-0.1-003-SC102-WAVE1/run/run-wave1.sh`
  - `rg -n "QT-0.1-003-SC102-WAVE1|Coverage status \(Wave 1\)|revision:" docs/30-catalog/scenarios/SC-102.md docs/40-qualification/README.md docs/40-qualification/QT-0.1-003-SC102-WAVE1/README.md`
- Negative:
  - Before this change there was no aggregate gate folder for SC-102 Wave 1 and no explicit coverage section in `SC-102.md`.

## Commands run
```bash
bash -n docs/40-qualification/QT-0.1-003-SC102-WAVE1/run/run-wave1.sh
rg -n "QT-0.1-003-SC102-WAVE1|Coverage status \(Wave 1\)|revision:" docs/30-catalog/scenarios/SC-102.md docs/40-qualification/README.md docs/40-qualification/QT-0.1-003-SC102-WAVE1/README.md
git status -sb
```
