### PR TITLE
chore(data): move research assets to yai-ops (pointer only)

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,5 +1,6 @@
 # Data
 
-This directory contains data assets only.
+Runtime repository does not store research datasets or benchmark seeds.
 
-Tooling scripts must live under `tools/data/`.
+Canonical location:
+- yai-ops/research/


### PR DESCRIPTION
Moves non-runtime research data out of the runtime repo.

- Runtime repo keeps only a pointer in data/README.md
- Canonical location: yai-ops/research/

Follow-up: merge yai-ops PR that imports the actual assets.