### PR TITLE
docs(runtime): workspace-first surface terminology alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository does not own:
 - Evidence and traceability as first-class artifacts
 - Pinned contract consumption with explicit upgrade discipline
 - Mind surfaces governed as part of platform architecture (scope-dependent in program phases)
+- Workspace-first runtime operations with kernel-owned workspace state
 
 ## Program anchors
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ This directory is the primary documentation entrypoint for the YAI platform impl
 
 - Normative contract authority is pinned from `deps/yai-law/`.
 - Operational evidence bundles and field collateral are maintained in `yai-ops`.
-- CLI and SDK operator/control surfaces are maintained in `yai-cli` and `yai-sdk`.
+- CLI and SDK command/control surfaces are maintained in `yai-cli` and `yai-sdk`.
 
 ## Interpretation rule
 

--- a/docs/program/23-runbooks/workspaces-lifecycle.md
+++ b/docs/program/23-runbooks/workspaces-lifecycle.md
@@ -348,8 +348,8 @@ The registry is already expanded (200 IDs per group). Workspace lifecycle v2 MUS
 - If runtime handler is missing, response MUST be deterministic (`nyi`/mapped equivalent), never `unknown command`.
 - Help surfaces MUST expose both overview and full catalog views:
   - `yai help` -> overview (compact)
-  - `yai help <group>` -> compact group overview
-  - `yai help <group>:all` -> full group command expansion
+  - `yai help <entrypoint>` -> compact entrypoint overview
+  - `yai help --all` / `yai help --plumbing` -> expanded command surfaces
 
 ### 11.6 Mediation hard rule
 CLI access is always mediated by governance plane:


### PR DESCRIPTION
Issue-ID: N/A
MP-ID: N/A
Runbook: N/A
Base-Commit: c172c3bf5c7c109a2dc2630d9425649cda917766
Classification: docs
Compatibility: no runtime/API change

## Summary
- align runtime README/docs wording with workspace-first command surface narrative
- replace legacy help references using <group> syntax in lifecycle runbook
- keep public docs consistent with entrypoint/topic/op model

## Evidence
- Positive:
  - README/docs language now consistently uses command-surface and workspace-first terms.
  - Lifecycle runbook help references no longer use the old <group> syntax.
- Negative:
  - No runtime source behavior changes.
  - No contract or protocol payload changes.

## Commands run
```bash
rg -n "help <group>|operator interface|workspace-first" README.md docs
```
